### PR TITLE
Make (cmd-line) on chicken work as expected.

### DIFF
--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -95,7 +95,7 @@
    (import (chicken process-context))
 
    (define (cmd-line)
-     (command-line-arguments)))
+     (cons (program-name) (command-line-arguments))))
 
   (else
 


### PR DESCRIPTION
Always returns a list of at least one element now. Fixes issue #13.