### PR TITLE
fix make check on idris2 host

### DIFF
--- a/src/host/idr/makefile
+++ b/src/host/idr/makefile
@@ -6,9 +6,10 @@ check:
 	  options=`sed -n -e '/;;;options:/p' $$prog | sed -e 's/^;;;options://'`; \
 	  echo "---------------------- $$prog [options:$$options]"; \
 	  rm -rf test.idr*; \
-	  gsi ../../rsc.scm -t idr $$options -o test.idr $$prog; \
+	  ../../rsc -t idr $$options -o test.idr $$prog; \
 	  idris2 -o test.idr.exe --output-dir . test.idr; \
 	  sed -n -e '/;;;input:/p' $$prog | sed -e 's/^;;;input://' | ./test.idr.exe > test.idr.out; \
+	  sleep 1 `# For some reason, idris2 takes time to write to file`;  \
 	  sed -e '1,/;;;expected:/d' -e 's/^;;;//' $$prog | diff - test.idr.out; \
 	done
 


### PR DESCRIPTION
For some reason, idris2 executable generated with ribbit sometimes exits before writing to stdout. This is problematic because when doing the `make check` the result of the previous test is compared against the current one; thus not passing it. I don't know if it's an issue with Idris2, the makefile, or the rvm. I found an easy (but a bit ugly) fix, which is to use a sleep 1 before comparing results.

Please check if it works on your machine before merging