### PR TITLE
Leo-ard/primitives

### DIFF
--- a/src/extract.scm
+++ b/src/extract.scm
@@ -1,0 +1,471 @@
+
+(define (string-from-file path)
+  (call-with-input-file path (lambda (port) (read-line port #f))))
+
+#;(define (extract-forms str)
+
+  
+
+
+
+
+  )
+
+#;(define (string-split str sep-code)
+  
+  (let loop ((start-split 0)
+             (char-index 0)
+             (result '()))
+    (if (< char-index (string-length str))
+      (let ((current-char (char->integer (string-ref str char-index))))
+        (if (= current-char sep-code) ; #;@
+          (loop (+ 1 char-index) 
+                (+ 1 char-index) 
+                (append 
+                  result 
+                  (cons (substring str start-split char-index) '())))
+          (loop start-split
+                (+ 1 char-index)
+                result)))
+      result)))
+
+#;(define (escape-string str)
+  (let loop ((i 0) (start 0) (result ""))
+    (let ((current-char (char->integer (string-ref str i))))
+      (if (< i (- (string-length str) 1))
+        (if (= current-char 34) ; #\"
+          (begin
+            (loop
+              (+ 1 i)
+              (+ 1 i)
+              (string-append 
+                result
+                (string-append (substring str start i) "\\\""))))
+          (loop
+            (+ 1 i)
+            start
+            result))    
+
+        (string-append "\""
+                       (string-append result  
+                                      (string-append (substring str start i)
+                                                     "\"")))))))
+
+(define (escape-string str)
+  (let ((p (open-output-string)))
+    (write str p)
+    (get-output-string p)))
+
+(define (parse-host-file file-str)
+  (define MACRO_CHAR 64) ;#\@
+
+  (let ((str-len (string-length file-str)))
+    (let loop ((i 0) 
+               (start 0)
+               (last-new-line 0)
+               (current-macro #f)
+               (parsed-file '()))
+
+      (if (< i (- str-len 2))
+        (let* ((current-char      (char->integer (string-ref file-str i)))
+               (next-char         (char->integer (string-ref file-str (+ i 1))))
+               (next-next-char    (char->integer (string-ref file-str (+ i 2))))
+               (last-new-line     (if (= current-char 10) i last-new-line)))
+          (cond 
+            ((and 
+               (not current-macro)
+               (= current-char MACRO_CHAR)
+               (= next-char    MACRO_CHAR)
+               (= next-next-char 40))
+             (loop (+ 2 i)
+                   start
+                   last-new-line
+                   (cons (cons 'head (cons last-new-line (cons i '()))) '()) ;; '((head ,last-new-line ,i))
+                   (append parsed-file (cons (cons '%str (cons start (cons i '()))) '()))))
+
+            ((and 
+               (not current-macro)
+               (= current-char MACRO_CHAR)
+               (= next-char    MACRO_CHAR)
+               (= next-next-char 41))
+             (cons (cons (+ 2 i) last-new-line) 
+                   (append parsed-file 
+                           (cons (cons '%str 
+                                       (cons 
+                                         start
+                                         (cons i '()))) 
+                                 '()))))
+             ((and
+                current-macro
+                (= current-char MACRO_CHAR)
+                (= next-char MACRO_CHAR))
+              (let* ((num-parents 1)
+                     #;(_ (pp current-macro))
+                     (macro-start (+ 2 (caddr (assq 'head current-macro))))
+                     (macro-string (substring file-str macro-start i))
+                     (p (open-input-string 
+                          (string-append macro-string (make-string num-parents (integer->char 41)))))
+                     (macro-sexp (read p))
+                     (last-char (read-char p))
+                     (macro-ended (not (eq? last-char #!eof))))
+                (if macro-ended
+                  (loop (+ i 2)
+                        (+ i 2)
+                        last-new-line
+                        #f
+                        (append
+                          parsed-file
+                          (cons
+                            (append macro-sexp current-macro)
+                            '())))
+                  (let* ((body-pair
+                           (loop (+ i 2)
+                                 (+ i 2)
+                                 last-new-line
+                                 #f
+                                 '()))
+                         (body-i (caar body-pair))
+                         (body-last-new-line (cdar body-pair))
+                         (body (cdr body-pair)))
+                    (loop body-i
+                          body-i
+                          body-last-new-line
+                          #f
+                          (append 
+                            parsed-file
+                            (cons (append macro-sexp (append current-macro (cons (cons 'body (cons body '())) '()))) '())))))))
+
+             (else
+               (loop (+ i 1)
+                     start
+                     last-new-line
+                     current-macro
+                     parsed-file))))
+          (append parsed-file (cons (cons '%str (cons start (cons i '()))) '()))))))
+
+#;(define (extract-primitives parsed-file)
+  (let* ((primitives (assoc 'primitives parsed-file))
+         (body (cadr (assoc 'body (cdr primitives)))))
+    (let loop ((body body))
+      (if (and (pair? body)
+               (pair? (car body)))
+        (if (eq? (caar body) 'primitive)
+          (cons (car body) (loop (cdr body)))
+          (loop (cdr body))
+          )
+        '()))))
+
+#;(define (extract walker parsed-file base)
+  (let loop ((acc base) (lst parsed-file))
+    (if (pair? lst)
+      (loop (walker (car lst) acc) 
+            (cdr lst))
+      acc)))
+
+(define (find predicate lst)
+  (if (pair? lst)
+    (if (predicate (car lst))
+      (car lst)
+      (find predicate (cdr lst)))
+    #f))
+
+(define (soft-assoc sym lst)
+  (find (lambda (e) (and (pair? e) (eq? (car e) sym)))
+        lst))
+
+
+(define (extract-primitives parsed-file)
+  (extract-predicate (lambda (prim) (eq? (car prim) 'primitive)) parsed-file))
+
+(define (extract-features parsed-file)
+  (extract-predicate (lambda (prim) (eq? (car prim) 'feature)) parsed-file))
+
+(define (extract-predicate predicate parsed-file)
+  (extract (lambda (prim acc)
+             (if (predicate prim)
+               (cons prim acc)
+               acc))
+           parsed-file
+           '()))
+
+(define (extract walker parsed-file base)
+  (letrec ((func 
+             (lambda (prim acc)
+               (let* ((name (car prim))
+                      (body (soft-assoc 'body (cdr prim)))
+                      (rec (if body 
+                             (fold func base (cadr body))
+                             base)))
+                 (walker prim (append acc rec))))))
+    (fold
+      func
+      base
+      parsed-file)))
+
+
+(define (needed-features features activated-prims)
+  
+  (let loop ((used-features (fold (lambda (prim acc) 
+                               (let ((uses (soft-assoc 'uses prim)))
+                                 (if uses
+                                   (append (cdr uses) acc)
+                                   acc)))
+                             '()
+                             activated-prims))
+             (needed-features '()))
+    (let* ((current (car used-features))
+           (current-used (find (lambda (feature) (eq? feature current))
+                               features)))
+
+      
+      )))
+
+#;(define (needed-features wanted-prims all-prims-and-features)
+  
+  
+  )
+
+
+
+#;(define (parse-host-file file-str)
+  (define MACRO_CHAR 64) ;#\@
+
+  (let ((str-len (string-length file-str)))
+    (let loop ((i 0) 
+               (start 0)
+               (inside-macro #f)
+               (enclose-code? #f) ; code read is enclosed inside an sexp
+               (last-new-line 0)
+               (current-str "(")) ;; start of list
+
+      (if (< i (- str-len 2))
+        (let* ((current-char      (char->integer (string-ref file-str i)))
+               (next-char         (char->integer (string-ref file-str (+ i 1))))
+               (next-next-char    (char->integer (string-ref file-str (+ i 2))))
+               (last-new-line     (if (= current-char 10) i last-new-line)))
+
+          (if (not inside-macro)
+            (cond 
+              ((and (= current-char MACRO_CHAR)  ;; #\@
+                    (= next-char    MACRO_CHAR)
+                    (or (= next-next-char    40)
+                        (= next-next-char    41))) ;; #\(
+               (loop (+ 3 i)
+                     (+ 2 i)
+                     #t
+                     enclose-code?
+                     last-new-line
+                     (if enclose-code?
+                       (string-append current-str 
+                                      (escape-string (substring file-str start i)))
+                       (string-append current-str
+                                      (string-append "(string "
+                                                     (string-append (escape-string (substring file-str start last-new-line))
+                                                                    ")")))))) 
+
+              (else
+                (loop (+ 1 i)
+                      start
+                      inside-macro
+                      enclose-code?
+                      last-new-line
+                      current-str)))
+            (if (and (= current-char MACRO_CHAR)
+                     (= next-char    MACRO_CHAR)) ;; #\@
+              (let* ((num-parents 2)
+                     (input-string 
+                       (string-append current-str
+                                      (substring file-str start i)))
+                     (p (open-input-string 
+                          (string-append input-string (make-string num-parents (integer->char 41)))))
+                     (last-char (begin (read p) (read-char p)))
+                     (last-char-int (if (eq? last-char #!eof) -1 (char->integer last-char)))
+                     (new-enclose-code? (not (= last-char-int 41)))) ; #\)
+                (loop (+ 2 i)
+                      (if new-enclose-code?
+                        last-new-line
+                        (+ 2 i))
+                      #f
+                      new-enclose-code?
+                      last-new-line
+                      (if (and (not new-enclose-code?) (not enclose-code?)) ; happen when same line expression
+                        (string-append 
+                            current-str
+                            (string-append 
+                              (substring file-str start (- i 1))
+                              (string-append 
+                                (escape-string (substring file-str last-new-line i))
+                                ")")))
+                        input-string)
+
+                      ))
+              (loop (+ 1 i)
+                    start
+                    inside-macro
+                    enclose-code?
+                    last-new-line
+                    current-str))))
+        (string-append current-str 
+                       (string-append "(string "
+                                      (string-append (escape-string (substring file-str start (+ i 2)))
+                                                     "))")))))))
+
+
+(define (extract-prims parsed-file)
+  (let* ((replace-value "")
+         (prefix-first-value "")
+         (prefix-rest-value "")
+         (result '())
+         (extract-prims-for-each
+           (lambda (expr)
+             (case (car expr)
+               ((rvm-prim) 
+                (set! result 
+                  (append
+                    result
+                    (cons 
+                      (cons (cadr expr)   ;;signature of primitive
+                            (caddr expr))
+                      '())))) ;; code
+               ((rvm-prim-generator-setup)
+                (for-each 
+                  (lambda (pair)
+                    (if (pair? pair)
+                      (case (car pair)
+                        ((prefix) (set! prefix-first-value (cadr pair))
+                                  (set! prefix-rest-value  (caddr pair)))
+                        ((replace) (set! replace-value (cadr pair)))
+                        (else (error "Unexpected keyword argument in (rvm-prim-generator-setup ...) in host file" (car pair))))))
+                  (cdr expr)))
+               ((string) (begin #f))
+               (else (error "Invalid expression while evaluating parsed host document. Currently accepted are rvm-prim and rvm-prim-generator-setup." expr))))))
+    (map extract-prims-for-each parsed-file)
+    result))
+
+(define (is-num? c)
+  (and (>= c 47)
+       (<= c 57)))
+
+(define (find-pattern pattern str start) 
+
+  (let loop ((i start) (lst-pattern pattern))
+    (cond 
+      ((not (pair? lst-pattern))
+       (cons start (- i 1)))
+      ((>= i (string-length str))
+       #f)
+      (else
+        (let* ((c-str (char->integer (string-ref str i)))
+               (c-pattern (car lst-pattern))
+               (c-pattern (if (char? c-pattern) 
+                            (char->integer c-pattern)
+                            c-pattern)))
+          (cond 
+            ((number? c-pattern)
+             (if (= c-pattern c-str)
+               (loop (+ i 1) (cdr lst-pattern))
+               (find-pattern pattern str (+ 1 start))))
+            ((and (eq? c-pattern '%INDEX%)
+                  (is-num? c-str))
+             (let skip ((i (+ 1 i)))
+               (if (>= i (string-length str))
+                 (loop i (cdr pattern))
+                 (let ((c-str (char->integer (string-ref str i))))
+                   (if (is-num? c-str)
+                     (skip (+ 1 i))
+                     (loop i (cdr lst-pattern)))))))
+            (else
+              (find-pattern pattern str (+ 1 start)))))))))
+
+(define (to-pattern lst)
+  (fold (lambda (x lst) 
+          (cond
+            ((string? x)
+             (append lst
+                     (string->list x)))
+            ((symbol? x)
+             (append lst
+                     (cons x '())))
+            (else
+              (error "Unknown pattern " x))))
+  '()
+  lst)
+  )
+
+
+(define (test-find-pattern)
+  (define (assert x y)
+    (or (equal? x y)
+        (error "This is not equal" x y)))
+
+  (define (test-pattern pattern str output)
+    (println "testing pattern \"" pattern "\" with string \"" str "\"")
+    (assert (find-pattern (to-pattern pattern) str 0) output))
+
+  (test-pattern '("hello") "hello" '(0 . 4))
+  (test-pattern '("hello world") "" #f)
+  ;(test-pattern '() "hello world" #f)
+  (test-pattern '("case " %INDEX% " :") "gad case 0 :" '(4 . 11)))
+
+(test-find-pattern)
+
+(define (generate-file parsed-file prims)
+  (let* ((replace-value "")
+         (prefix-first-value "")
+         (prefix-rest-value "")
+         (first-rvm-prim #t)
+         (generated-file "")
+         (apply-modifs 
+           (lambda (prim-code first?) 
+             (let ((prim-code (replace replace-value prim-code)))
+               (if first? 
+                 (string-append prefix-first-value prim-code)
+                 (string-append prefix-rest-value  prim-code))))))
+    (let loop ((parsed-file parsed-file))
+      (if (not (pair? parsed-file))
+        generated-file
+        (let ((expr (car parsed-file)))
+          (case (car expr) 
+            ((rvm-prim) 
+             (if first-rvm-prim
+               (begin
+                 (set! generated-file
+                   (string-append
+                     generated-file
+                     (apply string-append 
+                            (cons (apply-modifs (car prims) #t)
+                                  (map 
+                                    (lambda (prim) 
+                                      (apply-modifs prim #f) ) (cdr prims))))))
+                 (set! first-rvm-prim #f))))
+            ((rvm-prim-generator-setup)
+             (for-each 
+               (lambda (pair)
+                 (if (pair? pair)
+                   (case (car pair)
+                     ((prefix) (set! prefix-first-value (cadr pair))
+                               (set! prefix-rest-value  (caddr pair)))
+                     ((replace) (set! replace-value (cadr pair)))
+                     (else (error "Unexpected keyword argument in (define-prim-generator ...) in host file" (car pair))))))
+               (cdr expr)))
+
+            ((string)
+             (if (or first-rvm-prim
+                     (not (assq 'rvm-prims parsed-file)))
+               (set! generated-file (string-append generated-file (cadr expr)))))
+            (else (error "Invalid expression while evaluating parsed host document" expr)))
+          (loop (cdr parsed-file)))))))
+
+
+(let* ((r (parse-host-file (string-from-file "host/c/rvm.c")))
+       (show-this '(rib rib? putchar getchar eqv? add))
+       (prims (extract-primitives r))
+       (features (extract-features r))
+       #;(prims-simplified 
+         (map (lambda (x) (cons (caar x) (cdr x)))
+              prims)))
+  
+  (pp prims)
+  (pp features))
+
+

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -400,9 +400,9 @@ obj boolean(bool x) { return x ? CAR(FALSE) : FALSE; }
 void prim(int no) {
   switch (no) {
     // @(set-default-replace "case " %INDEX% ":{")
-  // @@(rvm-prim-generator-setup (replace "case " %INDEX% ": {"))@@
+  // @@(primitive-generator-setup (replace "case " %INDEX% ": {"))@@
 
-  case 0: { // @@(rvm-prim (rib a b c) @@
+  case 0: { // @@(primitive (rib a b c) @@
     obj new_rib = TAG_RIB(alloc_rib(NUM_0, NUM_0, NUM_0));
     PRIM3();
     CAR(new_rib) = x;
@@ -412,93 +412,93 @@ void prim(int no) {
     break;
     
   } // @@)@@
-  case 1: { // @@(rvm-prim (id x)@@
+  case 1: { // @@(primitive (id x)@@
     PRIM1();
     push2(x, PAIR_TAG);
     break;
   } // @@)@@
-  case 2: { // @@(rvm-prim (arg1 rib)@@
+  case 2: { // @@(primitive (arg1 x y)@@
     pop();
     break;
   } // @@)@@
-  case 3: { // @@(rvm-prim (arg2 rib)@@
+  case 3: { // @@(primitive (arg2 x y)@@
     obj x = pop();
     pop();
     push2(x, PAIR_TAG);
     break;
   } //@@)@@
-  case 4: { // @@(rvm-prim (close)@@
+  case 4: { // @@(primitive (close rib)@@
     obj x = CAR(TOS);
     obj y = CDR(stack);
     TOS = TAG_RIB(alloc_rib(x, y, CLOSURE_TAG));
     break;
   } //@@)@@
-  case 5: { // @@(rvm-prim (rib? rib)@@
+  case 5: { // @@(primitive (rib? rib)@@
     PRIM1();
     push2(boolean(IS_RIB(x)), PAIR_TAG);
     break;
   } //@@)@@
-  case 6: { // @@(rvm-prim (field0 rib)@@
+  case 6: { // @@(primitive (field0 rib)@@
     PRIM1();
     push2(CAR(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 7: { // @@(rvm-prim (field1 rib)@@
+  case 7: { // @@(primitive (field1 rib)@@
     PRIM1();
     push2(CDR(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 8: { // @@(rvm-prim (field2 rib)@@
+  case 8: { // @@(primitive (field2 rib)@@
     PRIM1();
     push2(TAG(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 9: { // @@(rvm-prim (field0-set! rib x)@@
+  case 9: { // @@(primitive (field0-set! rib x)@@
     PRIM2();
     push2(CAR(x) = y, PAIR_TAG);
     break;
   } //@@)@@
-  case 10: { // @@(rvm-prim (field1-set! rib x)@@
+  case 10: { // @@(primitive (field1-set! rib x)@@
     PRIM2();
     push2(CDR(x) = y, PAIR_TAG);
     break;
   } //@@)@@
-  case 11: { // @@(rvm-prim (field2-set! rib x)@@
+  case 11: { // @@(primitive (field2-set! rib x)@@
     PRIM2();
     push2(TAG(x) = y, PAIR_TAG);
     break;
   } // @@)@@
-  case 12: { // @@(rvm-prim (eqv? rib1 rib2)@@
+  case 12: { // @@(primitive (eqv? rib1 rib2)@@
     PRIM2();
     push2(boolean(x == y), PAIR_TAG);
     break;
   } //@@)@@
-  case 13: { // @@(rvm-prim (lt x y)@@
+  case 13: { // @@(primitive (lt x y)@@
     PRIM2();
     push2(boolean(NUM(x) < NUM(y)), PAIR_TAG);
     break;
   } //@@)@@
-  case 14: { // @@(rvm-prim (add x y)@@
+  case 14: { // @@(primitive (add x y)@@
     PRIM2();
     push2(x + y - 1, PAIR_TAG);
     break;
   } //@@)@@
-  case 15: { // @@(rvm-prim (sub x y)@@
+  case 15: { // @@(primitive (sub x y)@@
     PRIM2();
     push2(x - y + 1, PAIR_TAG);
     break;
   } //@@)@@
-  case 16: { // @@(rvm-prim (mul x y)@@
+  case 16: { // @@(primitive (mul x y)@@
     PRIM2();
     push2(TAG_NUM((NUM(x) * NUM(y))), PAIR_TAG);
     break;
   } // @@)@@
-  case 17: { // @@(rvm-prim (div x y)@@
+  case 17: { // @@(primitive (div x y)@@
     PRIM2();
     push2(TAG_NUM((NUM(x) / NUM(y))), PAIR_TAG);
     break;
   } // @@)@@
-  case 18: { // @@(rvm-prim (getchar)@@
+  case 18: { // @@(primitive (getchar)@@
     int read;
 #ifdef NO_STD
     asm volatile("push %%eax\n"
@@ -519,7 +519,7 @@ void prim(int no) {
     push2(TAG_NUM(read), PAIR_TAG);
     break;
   } // @@)@@
-  case 19: { // @@(rvm-prim (putchar c)@@
+  case 19: { // @@(primitive (putchar c)@@
     PRIM1();
 #ifdef NO_STD
     {
@@ -542,7 +542,7 @@ void prim(int no) {
     push2(x, PAIR_TAG);
     break;
   } // @@)@@
-  case 20: { // @@(rvm-prim (exit)@@
+  case 20: { // @@(primitive (exit n)@@
     PRIM1();
     vm_exit(NUM(x));
     break;

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -1,7 +1,7 @@
 /*
  * The Ribbit VM implementation in C
  */
-#ifdef DEBUG_I_CALL
+#ifdef DEBUG_I_CALL // @@(same-line "hey")@@
 #define DEBUG
 #endif
 
@@ -395,14 +395,15 @@ void show_operand(obj o) {
 
 #endif
 
+// @@(feature boolean@@
 obj boolean(bool x) { return x ? CAR(FALSE) : FALSE; }
+// @@)@@
 
 void prim(int no) {
-  switch (no) {
-    // @(set-default-replace "case " %INDEX% ":{")
-  // @@(primitive-generator-setup (replace "case " %INDEX% ": {"))@@
-
-  case 0: { // @@(primitive (rib a b c) @@
+  switch (no) { 
+  // @@(primitives (gen "\ncase " index ":" body "\n") @@
+  case 0: // @@(primitive (rib a b c) @@
+  {
     obj new_rib = TAG_RIB(alloc_rib(NUM_0, NUM_0, NUM_0));
     PRIM3();
     CAR(new_rib) = x;
@@ -412,93 +413,111 @@ void prim(int no) {
     break;
     
   } // @@)@@
-  case 1: { // @@(primitive (id x)@@
+  case 1: // @@(primitive (id x)@@
+  {
     PRIM1();
     push2(x, PAIR_TAG);
     break;
   } // @@)@@
-  case 2: { // @@(primitive (arg1 x y)@@
+  case 2: // @@(primitive (arg1 x y)@@
+  {
     pop();
     break;
   } // @@)@@
-  case 3: { // @@(primitive (arg2 x y)@@
+  case 3: // @@(primitive (arg2 x y)@@
+  {
     obj x = pop();
     pop();
     push2(x, PAIR_TAG);
     break;
   } //@@)@@
-  case 4: { // @@(primitive (close rib)@@
+  case 4: // @@(primitive (close rib)@@
+  {
     obj x = CAR(TOS);
     obj y = CDR(stack);
     TOS = TAG_RIB(alloc_rib(x, y, CLOSURE_TAG));
     break;
   } //@@)@@
-  case 5: { // @@(primitive (rib? rib)@@
+  case 5: // @@(primitive (rib? rib) (uses boolean)@@
+  {
     PRIM1();
     push2(boolean(IS_RIB(x)), PAIR_TAG);
     break;
   } //@@)@@
-  case 6: { // @@(primitive (field0 rib)@@
+  case 6: // @@(primitive (field0 rib)@@
+  {
     PRIM1();
     push2(CAR(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 7: { // @@(primitive (field1 rib)@@
+  case 7: // @@(primitive (field1 rib)@@
+  {
     PRIM1();
     push2(CDR(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 8: { // @@(primitive (field2 rib)@@
+  case 8:  // @@(primitive (field2 rib)@@
+  {
     PRIM1();
     push2(TAG(x), PAIR_TAG);
     break;
   } //@@)@@
-  case 9: { // @@(primitive (field0-set! rib x)@@
+  case 9: // @@(primitive (field0-set! rib x)@@
+  { 
     PRIM2();
     push2(CAR(x) = y, PAIR_TAG);
     break;
   } //@@)@@
-  case 10: { // @@(primitive (field1-set! rib x)@@
+  case 10:  // @@(primitive (field1-set! rib x)@@
+  {
     PRIM2();
     push2(CDR(x) = y, PAIR_TAG);
     break;
   } //@@)@@
-  case 11: { // @@(primitive (field2-set! rib x)@@
+  case 11:  // @@(primitive (field2-set! rib x)@@
+  {
     PRIM2();
     push2(TAG(x) = y, PAIR_TAG);
     break;
   } // @@)@@
-  case 12: { // @@(primitive (eqv? rib1 rib2)@@
+  case 12:  // @@(primitive (eqv? rib1 rib2) (uses boolean)@@
+  {
     PRIM2();
     push2(boolean(x == y), PAIR_TAG);
     break;
   } //@@)@@
-  case 13: { // @@(primitive (lt x y)@@
+  case 13:  // @@(primitive (lt x y) (uses boolean)@@
+  {
     PRIM2();
     push2(boolean(NUM(x) < NUM(y)), PAIR_TAG);
     break;
   } //@@)@@
-  case 14: { // @@(primitive (add x y)@@
+  case 14:  // @@(primitive (add x y)@@
+  {
     PRIM2();
     push2(x + y - 1, PAIR_TAG);
     break;
   } //@@)@@
-  case 15: { // @@(primitive (sub x y)@@
+  case 15:  // @@(primitive (sub x y)@@
+  {
     PRIM2();
     push2(x - y + 1, PAIR_TAG);
     break;
   } //@@)@@
-  case 16: { // @@(primitive (mul x y)@@
+  case 16:  // @@(primitive (mul x y)@@
+  {
     PRIM2();
     push2(TAG_NUM((NUM(x) * NUM(y))), PAIR_TAG);
     break;
   } // @@)@@
-  case 17: { // @@(primitive (div x y)@@
+  case 17:  // @@(primitive (div x y)@@
+  {
     PRIM2();
     push2(TAG_NUM((NUM(x) / NUM(y))), PAIR_TAG);
     break;
   } // @@)@@
-  case 18: { // @@(primitive (getchar)@@
+  case 18:  // @@(primitive (getchar)@@
+  {
     int read;
 #ifdef NO_STD
     asm volatile("push %%eax\n"
@@ -519,7 +538,8 @@ void prim(int no) {
     push2(TAG_NUM(read), PAIR_TAG);
     break;
   } // @@)@@
-  case 19: { // @@(primitive (putchar c)@@
+  case 19:  // @@(primitive (putchar c)@@ 
+  {
     PRIM1();
 #ifdef NO_STD
     {
@@ -542,16 +562,17 @@ void prim(int no) {
     push2(x, PAIR_TAG);
     break;
   } // @@)@@
-  case 20: { // @@(primitive (exit n)@@
+  case 20:  // @@(primitive (exit n)@@
+  {
     PRIM1();
     vm_exit(NUM(x));
     break;
   } //@@)@@
+  // @@)@@
   default: {
     vm_exit(EXIT_ILLEGAL_INSTR);
   }
   }
-  // )
 }
 
 void run() {

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -399,7 +399,10 @@ obj boolean(bool x) { return x ? CAR(FALSE) : FALSE; }
 
 void prim(int no) {
   switch (no) {
-  case 0: { // rib
+    // @(set-default-replace "case " %INDEX% ":{")
+  // @@(rvm-prim-generator-setup (replace "case " %INDEX% ": {"))@@
+
+  case 0: { // @@(rvm-prim (rib a b c) @@
     obj new_rib = TAG_RIB(alloc_rib(NUM_0, NUM_0, NUM_0));
     PRIM3();
     CAR(new_rib) = x;
@@ -407,94 +410,95 @@ void prim(int no) {
     TAG(new_rib) = z;
     push2(new_rib, PAIR_TAG);
     break;
-  }
-  case 1: { // id
+    
+  } // @@)@@
+  case 1: { // @@(rvm-prim (id x)@@
     PRIM1();
     push2(x, PAIR_TAG);
     break;
-  }
-  case 2: { // arg1
+  } // @@)@@
+  case 2: { // @@(rvm-prim (arg1 rib)@@
     pop();
     break;
-  }
-  case 3: { // arg2
+  } // @@)@@
+  case 3: { // @@(rvm-prim (arg2 rib)@@
     obj x = pop();
     pop();
     push2(x, PAIR_TAG);
     break;
-  }
-  case 4: { // close
+  } //@@)@@
+  case 4: { // @@(rvm-prim (close)@@
     obj x = CAR(TOS);
     obj y = CDR(stack);
     TOS = TAG_RIB(alloc_rib(x, y, CLOSURE_TAG));
     break;
-  }
-  case 5: { // is rib?
+  } //@@)@@
+  case 5: { // @@(rvm-prim (rib? rib)@@
     PRIM1();
     push2(boolean(IS_RIB(x)), PAIR_TAG);
     break;
-  }
-  case 6: { // field0
+  } //@@)@@
+  case 6: { // @@(rvm-prim (field0 rib)@@
     PRIM1();
     push2(CAR(x), PAIR_TAG);
     break;
-  }
-  case 7: { // field1
+  } //@@)@@
+  case 7: { // @@(rvm-prim (field1 rib)@@
     PRIM1();
     push2(CDR(x), PAIR_TAG);
     break;
-  }
-  case 8: { // field2
+  } //@@)@@
+  case 8: { // @@(rvm-prim (field2 rib)@@
     PRIM1();
     push2(TAG(x), PAIR_TAG);
     break;
-  }
-  case 9: { // set field0
+  } //@@)@@
+  case 9: { // @@(rvm-prim (field0-set! rib x)@@
     PRIM2();
     push2(CAR(x) = y, PAIR_TAG);
     break;
-  }
-  case 10: { // set field1
+  } //@@)@@
+  case 10: { // @@(rvm-prim (field1-set! rib x)@@
     PRIM2();
     push2(CDR(x) = y, PAIR_TAG);
     break;
-  }
-  case 11: { // set field2
+  } //@@)@@
+  case 11: { // @@(rvm-prim (field2-set! rib x)@@
     PRIM2();
     push2(TAG(x) = y, PAIR_TAG);
     break;
-  }
-  case 12: { // eqv?
+  } // @@)@@
+  case 12: { // @@(rvm-prim (eqv? rib1 rib2)@@
     PRIM2();
     push2(boolean(x == y), PAIR_TAG);
     break;
-  }
-  case 13: { // lt
+  } //@@)@@
+  case 13: { // @@(rvm-prim (lt x y)@@
     PRIM2();
     push2(boolean(NUM(x) < NUM(y)), PAIR_TAG);
     break;
-  }
-  case 14: { // add
+  } //@@)@@
+  case 14: { // @@(rvm-prim (add x y)@@
     PRIM2();
     push2(x + y - 1, PAIR_TAG);
     break;
-  }
-  case 15: { // sub
+  } //@@)@@
+  case 15: { // @@(rvm-prim (sub x y)@@
     PRIM2();
     push2(x - y + 1, PAIR_TAG);
     break;
-  }
-  case 16: { // mul
+  } //@@)@@
+  case 16: { // @@(rvm-prim (mul x y)@@
     PRIM2();
     push2(TAG_NUM((NUM(x) * NUM(y))), PAIR_TAG);
     break;
-  }
-  case 17: { // div
+  } // @@)@@
+  case 17: { // @@(rvm-prim (div x y)@@
     PRIM2();
     push2(TAG_NUM((NUM(x) / NUM(y))), PAIR_TAG);
     break;
-  }
-  case 18: { // getc
+  } // @@)@@
+  case 18: { // @@(rvm-prim (getchar)@@
     int read;
 #ifdef NO_STD
     asm volatile("push %%eax\n"
@@ -514,8 +518,8 @@ void prim(int no) {
 #endif
     push2(TAG_NUM(read), PAIR_TAG);
     break;
-  }
-  case 19: { // putc
+  } // @@)@@
+  case 19: { // @@(rvm-prim (putchar c)@@
     PRIM1();
 #ifdef NO_STD
     {
@@ -537,16 +541,17 @@ void prim(int no) {
 #endif
     push2(x, PAIR_TAG);
     break;
-  }
-  case 20: { // exit
+  } // @@)@@
+  case 20: { // @@(rvm-prim (exit)@@
     PRIM1();
     vm_exit(NUM(x));
     break;
-  }
+  } //@@)@@
   default: {
     vm_exit(EXIT_ILLEGAL_INSTR);
   }
   }
+  // )
 }
 
 void run() {

--- a/src/host/js/rvm.js
+++ b/src/host/js/rvm.js
@@ -149,6 +149,7 @@ get_cont = () => { let s = stack; while (!s[2]) s = s[1]; return s; };
 prim1 = (f) => () => push(f(pop()));
 prim2 = (f) => () => push(f(pop(),pop()));
 prim3 = (f) => () => push(f(pop(),pop(),pop()));
+// @@(rvm-prim-generator-setup (prefix " " ","))@@
 
 primitives = [
   prim3((z, y, x) => [x, y, z]),                   // @@(rvm-prim  (rib a b c))@@
@@ -169,8 +170,8 @@ primitives = [
   prim2((y, x) => x-y),                            // @@(rvm-prim  (sub x y))@@
   prim2((y, x) => x*y),                            // @@(rvm-prim  (mul x y))@@
   prim2((y, x) => x/y|0),                          // @@(rvm-prim  (div x y))@@
-  getchar,                                         // @@(rvm-prim  (get-char))@@
-  prim1(putchar),                                  // @@(rvm-prim  (put-char c))@@
+  getchar,                                         // @@(rvm-prim  (getchar))@@
+  prim1(putchar),                                  // @@(rvm-prim  (putchar c))@@
   () => pop() && halt()//will crash with error on != 0 @@(rvm-prim (exit n))@@
 ];
 

--- a/src/host/js/rvm.js
+++ b/src/host/js/rvm.js
@@ -149,30 +149,30 @@ get_cont = () => { let s = stack; while (!s[2]) s = s[1]; return s; };
 prim1 = (f) => () => push(f(pop()));
 prim2 = (f) => () => push(f(pop(),pop()));
 prim3 = (f) => () => push(f(pop(),pop(),pop()));
-// @@(rvm-prim-generator-setup (prefix " " ","))@@
+// @@(primitive-generator-setup)@@
 
 primitives = [
-  prim3((z, y, x) => [x, y, z]),                   // @@(rvm-prim  (rib a b c))@@
-  prim1((x) => x),                                 // @@(rvm-prim  (id x))@@
-  () => (pop(), true),                             // @@(rvm-prim  (arg1 x y))@@
-  () => { let y = pop(); pop(); return push(y); }, // @@(rvm-prim  (arg2 x y))@@
-  () => push([pop()[0],stack,1]),                  // @@(rvm-prim  (close rib))@@
-  prim1((x) => to_bool(is_rib(x))),                // @@(rvm-prim  (rib? rib))@@
-  prim1((x) => x[0]),                              // @@(rvm-prim  (field0 rib))@@
-  prim1((x) => x[1]),                              // @@(rvm-prim  (field1 rib))@@
-  prim1((x) => x[2]),                              // @@(rvm-prim  (field2 rib))@@
-  prim2((y, x) => x[0]=y),                         // @@(rvm-prim  (field0-set! rib))@@
-  prim2((y, x) => x[1]=y),                         // @@(rvm-prim  (field1-set! rib))@@
-  prim2((y, x) => x[2]=y),                         // @@(rvm-prim  (field2-set! rib))@@
-  prim2((y, x) => to_bool(x===y)),                 // @@(rvm-prim  (eqv? x y))@@
-  prim2((y, x) => to_bool(x<y)),                   // @@(rvm-prim  (lt x y))@@
-  prim2((y, x) => x+y),                            // @@(rvm-prim  (add x y))@@
-  prim2((y, x) => x-y),                            // @@(rvm-prim  (sub x y))@@
-  prim2((y, x) => x*y),                            // @@(rvm-prim  (mul x y))@@
-  prim2((y, x) => x/y|0),                          // @@(rvm-prim  (div x y))@@
-  getchar,                                         // @@(rvm-prim  (getchar))@@
-  prim1(putchar),                                  // @@(rvm-prim  (putchar c))@@
-  () => pop() && halt()//will crash with error on != 0 @@(rvm-prim (exit n))@@
+  prim3((z, y, x) => [x, y, z]),                   //  @@(primitive  (rib a b c))@@
+  prim1((x) => x),                                 //  @@(primitive  (id x))@@
+  () => (pop(), true),                             //  @@(primitive  (arg1 x y))@@
+  () => { let y = pop(); pop(); return push(y); }, //  @@(primitive  (arg2 x y))@@
+  () => push([pop()[0],stack,1]),                  //  @@(primitive  (close rib))@@
+  prim1((x) => to_bool(is_rib(x))),                //  @@(primitive  (rib? rib))@@
+  prim1((x) => x[0]),                              //  @@(primitive  (field0 rib))@@
+  prim1((x) => x[1]),                              //  @@(primitive  (field1 rib))@@
+  prim1((x) => x[2]),                              //  @@(primitive  (field2 rib))@@
+  prim2((y, x) => x[0]=y),                         //  @@(primitive  (field0-set! rib))@@
+  prim2((y, x) => x[1]=y),                         //  @@(primitive  (field1-set! rib))@@
+  prim2((y, x) => x[2]=y),                         //  @@(primitive  (field2-set! rib))@@
+  prim2((y, x) => to_bool(x===y)),                 //  @@(primitive  (eqv? x y))@@
+  prim2((y, x) => to_bool(x<y)),                   //  @@(primitive  (lt x y))@@
+  prim2((y, x) => x+y),                            //  @@(primitive  (add x y))@@
+  prim2((y, x) => x-y),                            //  @@(primitive  (sub x y))@@
+  prim2((y, x) => x*y),                            //  @@(primitive  (mul x y))@@
+  prim2((y, x) => x/y|0),                          //  @@(primitive  (div x y))@@
+  getchar,                                         //  @@(primitive  (getchar))@@
+  prim1(putchar),                                  //  @@(primitive  (putchar c))@@
+  () => pop() && halt(),//will crash with error on != 0 @@(primitive (exit n))@@
 ];
 
 run = () => {

--- a/src/host/js/rvm.js
+++ b/src/host/js/rvm.js
@@ -151,27 +151,27 @@ prim2 = (f) => () => push(f(pop(),pop()));
 prim3 = (f) => () => push(f(pop(),pop(),pop()));
 
 primitives = [
-  prim3((z, y, x) => [x, y, z]),
-  prim1((x) => x),
-  () => (pop(), true),
-  () => { let y = pop(); pop(); return push(y); },
-  () => push([pop()[0],stack,1]),
-  prim1((x) => to_bool(is_rib(x))),
-  prim1((x) => x[0]),
-  prim1((x) => x[1]),
-  prim1((x) => x[2]),
-  prim2((y, x) => x[0]=y),
-  prim2((y, x) => x[1]=y),
-  prim2((y, x) => x[2]=y),
-  prim2((y, x) => to_bool(x===y)),
-  prim2((y, x) => to_bool(x<y)),
-  prim2((y, x) => x+y),
-  prim2((y, x) => x-y),
-  prim2((y, x) => x*y),
-  prim2((y, x) => x/y|0),
-  getchar,
-  prim1(putchar),
-  () => pop() && halt() // will crash with error on != 0
+  prim3((z, y, x) => [x, y, z]),                   // @@(rvm-prim  (rib a b c))@@
+  prim1((x) => x),                                 // @@(rvm-prim  (id x))@@
+  () => (pop(), true),                             // @@(rvm-prim  (arg1 x y))@@
+  () => { let y = pop(); pop(); return push(y); }, // @@(rvm-prim  (arg2 x y))@@
+  () => push([pop()[0],stack,1]),                  // @@(rvm-prim  (close rib))@@
+  prim1((x) => to_bool(is_rib(x))),                // @@(rvm-prim  (rib? rib))@@
+  prim1((x) => x[0]),                              // @@(rvm-prim  (field0 rib))@@
+  prim1((x) => x[1]),                              // @@(rvm-prim  (field1 rib))@@
+  prim1((x) => x[2]),                              // @@(rvm-prim  (field2 rib))@@
+  prim2((y, x) => x[0]=y),                         // @@(rvm-prim  (field0-set! rib))@@
+  prim2((y, x) => x[1]=y),                         // @@(rvm-prim  (field1-set! rib))@@
+  prim2((y, x) => x[2]=y),                         // @@(rvm-prim  (field2-set! rib))@@
+  prim2((y, x) => to_bool(x===y)),                 // @@(rvm-prim  (eqv? x y))@@
+  prim2((y, x) => to_bool(x<y)),                   // @@(rvm-prim  (lt x y))@@
+  prim2((y, x) => x+y),                            // @@(rvm-prim  (add x y))@@
+  prim2((y, x) => x-y),                            // @@(rvm-prim  (sub x y))@@
+  prim2((y, x) => x*y),                            // @@(rvm-prim  (mul x y))@@
+  prim2((y, x) => x/y|0),                          // @@(rvm-prim  (div x y))@@
+  getchar,                                         // @@(rvm-prim  (get-char))@@
+  prim1(putchar),                                  // @@(rvm-prim  (put-char c))@@
+  () => pop() && halt()//will crash with error on != 0 @@(rvm-prim (exit n))@@
 ];
 
 run = () => {

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1757,7 +1757,7 @@
          (extract-prims-for-each
            (lambda (expr)
              (case (car expr)
-               ((rvm-prim) 
+               ((primitive) 
                 (set! result 
                   (append
                     result
@@ -1765,7 +1765,7 @@
                       (cons (cadr expr)   ;;signature of primitive
                             (caddr expr))
                       '())))) ;; code
-               ((rvm-prim-generator-setup)
+               ((primitive-generator-setup)
                 (for-each 
                   (lambda (pair)
                     (if (pair? pair)
@@ -1773,12 +1773,12 @@
                         ((prefix) (set! prefix-first-value (cadr pair))
                                   (set! prefix-rest-value  (caddr pair)))
                         ((replace) (set! replace-value (cadr pair)))
-                        (else (error "Unexpected keyword argument in (rvm-prim-generator-setup ...) in host file" (car pair))))))
+                        (else (error "Unexpected keyword argument in (primitive-generator-setup ...) in host file" (car pair))))))
                   (cdr expr)))
                ((string) (begin #f))
                (else 
                  (error 
-                   "Invalid expression while evaluating parsed host document. Currently accepted are rvm-prim and rvm-prim-generator-setup." 
+                   "Invalid expression while evaluating parsed host document. Currently accepted are primitive and primitive-generator-setup." 
                    expr))))))
     (map extract-prims-for-each parsed-file)
     result))
@@ -1891,7 +1891,7 @@
         generated-file
         (let ((expr (car parsed-file)))
           (case (car expr) 
-            ((rvm-prim) 
+            ((primitive) 
              (if first-rvm-prim
                (begin
                  (set! generated-file
@@ -1901,20 +1901,20 @@
                             (map (lambda (x) (apply-modifs (car x) (cdr x)))
                                  prims-with-numbers))))
                  (set! first-rvm-prim #f))))
-            ((rvm-prim-generator-setup)
+            ((primitive-generator-setup)
              (for-each 
                (lambda (pair)
                  (if (pair? pair)
                    (case (car pair)
-                     ((prefix) (set! prefix-first-value (cadr pair))
+                     #;((prefix) (set! prefix-first-value (cadr pair))
                                (set! prefix-rest-value  (caddr pair)))
                      ((replace) (set! replace-value (cdr pair)))
-                     (else (error "Unexpected keyword argument in (define-prim-generator ...) in host file" (car pair))))))
+                     (else (error "Unexpected keyword argument in (primitive-generator-setup ...) in host file" (car pair))))))
                (cdr expr)))
 
             ((string)
              (if (or first-rvm-prim
-                     (not (assq 'rvm-prims parsed-file)))
+                     (not (assq 'primitive parsed-file)))
                (set! generated-file (string-append generated-file (cadr expr)))))
             (else (error "Invalid expression while evaluating parsed host document" expr)))
           (loop (cdr parsed-file)))))))

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1870,7 +1870,7 @@
       (error "Cannot find pattern in code" replace-value prim-code))))
 
 (define (generate-file parsed-file prims)
-  (let* ((replace-value "")
+  (let* ((replace-value #f)
          (prefix-first-value "")
          (prefix-rest-value "")
          (first-rvm-prim #t)
@@ -1882,12 +1882,10 @@
                '())))
          (apply-modifs 
            (lambda (prim-code index) 
-             (let ((prim-code (replace-pattern replace-value prim-code index)))
+             (let ((prim-code (if replace-value (replace-pattern replace-value prim-code index) prim-code)))
                (if (= index 0) 
                  (string-append prefix-first-value prim-code)
-                 (string-append prefix-rest-value  prim-code)))))
-         
-         )
+                 (string-append prefix-rest-value  prim-code))))))
     (let loop ((parsed-file parsed-file))
       (if (not (pair? parsed-file))
         generated-file
@@ -1952,7 +1950,8 @@
          (current-prims (extract-prims parsed-file))
          (prims-simplified (map (lambda (x) (cons (caar x) (cdr x))) current-prims) ) ;; remove signature of primitives to have '((rib . code) ...)
          (show-this '(rib rib? putchar getchar eqv? add)))
-    (generate-file parsed-file (map
+    (generate-file parsed-file 
+                   (map
                        (lambda (x)
                          (cdr (assq x prims-simplified)))
                        show-this))))

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1646,12 +1646,317 @@
               (read-all)
               (read-from-file src-path))))
 
+
+;;;----------------------------------------------------------------------------
+
+;; Host file expression parsing, evalutation and substitution
+
+
+(define (escape-string str)
+  (let ((p (open-output-string)))
+    (write str p)
+    (get-output-string p)))
+
+
+;; Takes the file as a string 
+(define (parse-host-file file-str)
+  (define MACRO_CHAR 64) ;#\@
+
+  (let ((str-len (string-length file-str)))
+    (let loop ((i 0) 
+               (start 0)
+               (inside-macro #f)
+               (enclose-code? #f) ; code read is enclosed inside an sexp
+               (last-new-line 0)
+               (current-str "(")) ;; start of list
+
+      (if (< i (- str-len 2))
+        (let* ((current-char      (char->integer (string-ref file-str i)))
+               (next-char         (char->integer (string-ref file-str (+ i 1))))
+               (next-next-char    (char->integer (string-ref file-str (+ i 2))))
+               (last-new-line     (if (= current-char 10) i last-new-line)))
+
+          (if (not inside-macro)
+            (cond 
+              ((and (= current-char MACRO_CHAR)  ;; #\@
+                    (= next-char    MACRO_CHAR)
+                    (or (= next-next-char    40)
+                        (= next-next-char    41))) ;; #\(
+               (loop (+ 3 i)
+                     (+ 2 i)
+                     #t
+                     enclose-code?
+                     last-new-line
+                     (if enclose-code?
+                       (string-append 
+                         current-str 
+                         (escape-string (substring file-str start i)))
+                       (string-append 
+                         current-str
+                         (string-append 
+                           "(string "
+                           (string-append 
+                             (escape-string 
+                               (substring file-str start last-new-line))
+                             ")")))))) 
+
+              (else
+                (loop (+ 1 i)
+                      start
+                      inside-macro
+                      enclose-code?
+                      last-new-line
+                      current-str)))
+            (if (and (= current-char MACRO_CHAR)
+                     (= next-char    MACRO_CHAR)) ;; #\@
+              (let* ((num-parents 2)
+                     (input-string 
+                       (string-append current-str
+                                      (substring file-str start i)))
+                     (p (open-input-string 
+                          (string-append input-string (make-string num-parents (integer->char 41)))))
+                     (last-char (begin (read p) (read-char p)))
+                     (last-char-int (if (eq? last-char #!eof) -1 (char->integer last-char)))
+                     (new-enclose-code? (not (= last-char-int 41)))) ; #\)
+                (loop (+ 2 i)
+                      (if new-enclose-code?
+                        last-new-line
+                        (+ 2 i))
+                      #f
+                      new-enclose-code?
+                      last-new-line
+                      (if (and (not new-enclose-code?) (not enclose-code?)) ; happen when same line expression
+                        (string-append 
+                          current-str
+                          (string-append 
+                            (substring file-str start (- i 1))
+                            (string-append 
+                              (escape-string (substring file-str last-new-line i))
+                              ")")))
+                        input-string)
+
+                      ))
+              (loop (+ 1 i)
+                    start
+                    inside-macro
+                    enclose-code?
+                    last-new-line
+                    current-str))))
+        (string-append current-str 
+                       (string-append "(string "
+                                      (string-append (escape-string (substring file-str start (+ i 2)))
+                                                     "))")))))))
+
+
+
+(define (extract-prims parsed-file)
+  (let* ((replace-value "")
+         (prefix-first-value "")
+         (prefix-rest-value "")
+         (result '())
+         (extract-prims-for-each
+           (lambda (expr)
+             (case (car expr)
+               ((rvm-prim) 
+                (set! result 
+                  (append
+                    result
+                    (cons 
+                      (cons (cadr expr)   ;;signature of primitive
+                            (caddr expr))
+                      '())))) ;; code
+               ((rvm-prim-generator-setup)
+                (for-each 
+                  (lambda (pair)
+                    (if (pair? pair)
+                      (case (car pair)
+                        ((prefix) (set! prefix-first-value (cadr pair))
+                                  (set! prefix-rest-value  (caddr pair)))
+                        ((replace) (set! replace-value (cadr pair)))
+                        (else (error "Unexpected keyword argument in (rvm-prim-generator-setup ...) in host file" (car pair))))))
+                  (cdr expr)))
+               ((string) (begin #f))
+               (else 
+                 (error 
+                   "Invalid expression while evaluating parsed host document. Currently accepted are rvm-prim and rvm-prim-generator-setup." 
+                   expr))))))
+    (map extract-prims-for-each parsed-file)
+    result))
+
+(define (is-num? c)
+  (and (>= c 47)
+       (<= c 57)))
+
+(define (find-pattern pattern str start) 
+
+  (let loop ((i start) (lst-pattern pattern))
+    (cond 
+      ((not (pair? lst-pattern))
+       (cons start (- i 1)))
+      ((>= i (string-length str))
+       #f)
+      (else
+        (let* ((c-str (char->integer (string-ref str i)))
+               (c-pattern (car lst-pattern))
+               (c-pattern (if (char? c-pattern) 
+                            (char->integer c-pattern)
+                            c-pattern)))
+          (cond 
+            ((number? c-pattern)
+             (if (= c-pattern c-str)
+               (loop (+ i 1) (cdr lst-pattern))
+               (find-pattern pattern str (+ 1 start))))
+            ((and (eq? c-pattern '%INDEX%)
+                  (is-num? c-str))
+             (let skip ((i (+ 1 i)))
+               (if (>= i (string-length str))
+                 (loop i (cdr pattern))
+                 (let ((c-str (char->integer (string-ref str i))))
+                   (if (is-num? c-str)
+                     (skip (+ 1 i))
+                     (loop i (cdr lst-pattern)))))))
+            (else
+              (find-pattern pattern str (+ 1 start)))))))))
+
+(define (to-pattern lst)
+  (fold 
+    (lambda (x lst) 
+      (cond
+        ((string? x)
+         (append lst
+                 (string->list x)))
+        ((symbol? x)
+         (append lst
+                 (cons x '())))
+        (else
+          (error "Unknown pattern " x))))
+    '()
+    lst))
+
+
+(define (test-find-pattern)
+  (define (assert x y)
+    (or (equal? x y)
+        (error "This is not equal" x y)))
+
+  (define (test-pattern pattern str output)
+    (println "testing pattern \"" pattern "\" with string \"" str "\"")
+    (assert (find-pattern (to-pattern pattern) str 0) output))
+
+  (test-pattern '("hello") "hello" '(0 . 4))
+  (test-pattern '("hello world") "" #f)
+  ;(test-pattern '() "hello world" #f)
+  (test-pattern '("case " %INDEX% " :") "gad case 0 :" '(4 . 11)))
+
+(define (generate-pattern pattern index)
+  (let loop ((pattern pattern))
+    (if (pair? pattern)
+      (string-append 
+        (cond ((string? (car pattern))
+               (car pattern))
+              ((eq? '%INDEX% (car pattern))
+               (number->string index))
+              (else (error "Error in pattern. Cannot generate " pattern)))
+        (loop (cdr pattern)))
+      "")))
+
+(define (replace-pattern replace-value prim-code index)
+  (let ((position (find-pattern (to-pattern replace-value) prim-code 0))
+        (generated-pattern (generate-pattern replace-value index)))
+    (if position
+      (string-append (substring prim-code 0 (car position))
+                     generated-pattern
+                     (substring prim-code (+ 1 (cdr position)) (string-length prim-code)))
+      (error "Cannot find pattern in code" replace-value prim-code))))
+
+(define (generate-file parsed-file prims)
+  (let* ((replace-value "")
+         (prefix-first-value "")
+         (prefix-rest-value "")
+         (first-rvm-prim #t)
+         (generated-file "")
+         (prims-with-numbers 
+           (let loop ((prims prims) (i 0))
+             (if (pair? prims)
+               (cons (cons (car prims) i) (loop (cdr prims) (+ 1 i)))
+               '())))
+         (apply-modifs 
+           (lambda (prim-code index) 
+             (let ((prim-code (replace-pattern replace-value prim-code index)))
+               (if (= index 0) 
+                 (string-append prefix-first-value prim-code)
+                 (string-append prefix-rest-value  prim-code)))))
+         
+         )
+    (let loop ((parsed-file parsed-file))
+      (if (not (pair? parsed-file))
+        generated-file
+        (let ((expr (car parsed-file)))
+          (case (car expr) 
+            ((rvm-prim) 
+             (if first-rvm-prim
+               (begin
+                 (set! generated-file
+                   (string-append
+                     generated-file
+                     (apply string-append 
+                            (map (lambda (x) (apply-modifs (car x) (cdr x)))
+                                 prims-with-numbers))))
+                 (set! first-rvm-prim #f))))
+            ((rvm-prim-generator-setup)
+             (for-each 
+               (lambda (pair)
+                 (if (pair? pair)
+                   (case (car pair)
+                     ((prefix) (set! prefix-first-value (cadr pair))
+                               (set! prefix-rest-value  (caddr pair)))
+                     ((replace) (set! replace-value (cdr pair)))
+                     (else (error "Unexpected keyword argument in (define-prim-generator ...) in host file" (car pair))))))
+               (cdr expr)))
+
+            ((string)
+             (if (or first-rvm-prim
+                     (not (assq 'rvm-prims parsed-file)))
+               (set! generated-file (string-append generated-file (cadr expr)))))
+            (else (error "Invalid expression while evaluating parsed host document" expr)))
+          (loop (cdr parsed-file)))))))
+
+
+
+
+
 ;;;----------------------------------------------------------------------------
 
 ;; Target code generation.
 
 (define (string-from-file path)
   (call-with-input-file path (lambda (port) (read-line port #f))))
+
+(define (transform-host-file host-file-str input)
+  (let* ((sample ");'u?>vD?>vRD?>vRA?>vRA?>vR:?>vR=!(:lkm!':lkv6y")
+         (host-str (string-replace
+                     (string-replace
+                       (string-replace
+                         (string-replace
+                           host-file-str
+                           sample
+                           input)
+                         (rvm-code-to-bytes sample " ")
+                         (rvm-code-to-bytes input " "))
+                       (rvm-code-to-bytes sample ",")
+                       (rvm-code-to-bytes input ","))
+                     "RVM code that prints HELLO!"
+                     "RVM code of the program"))
+         (parsed-file (read 
+                        (open-input-string (parse-host-file host-str))))
+         (current-prims (extract-prims parsed-file))
+         (prims-simplified (map (lambda (x) (cons (caar x) (cdr x))) current-prims) ) ;; remove signature of primitives to have '((rib . code) ...)
+         (show-this '(rib rib? putchar getchar eqv? add)))
+    (generate-file parsed-file (map
+                       (lambda (x)
+                         (cdr (assq x prims-simplified)))
+                       show-this))))
+
 
 (define (generate-code target verbosity input-path minify? proc-and-exports)
   (let* ((proc
@@ -1685,21 +1990,7 @@
     (let* ((target-code-before-minification
             (if (equal? target "rvm")
                 input
-                (let ((sample
-                       ");'u?>vD?>vRD?>vRA?>vRA?>vR:?>vR=!(:lkm!':lkv6y")) ;; RVM code that prints HELLO!
-                  (string-replace
-                   (string-replace
-                    (string-replace
-                     (string-replace
-                      vm-source
-                      sample
-                      input)
-                     (rvm-code-to-bytes sample " ")
-                     (rvm-code-to-bytes input " "))
-                    (rvm-code-to-bytes sample ",")
-                    (rvm-code-to-bytes input ","))
-                   "RVM code that prints HELLO!"
-                   "RVM code of the program"))))
+                (transform-host-file vm-source input)))
            (target-code
             (if (or (not minify?) (equal? target "rvm"))
                 target-code-before-minification


### PR DESCRIPTION
Primitives can be selected with more flexibility. To use this feature, use the `-p` command line on the rsc.scm file. For example, the following command will only generate a host file with the `rib` and `rib?` primitive. 

```
gsi rsc.scm -t js -l max -p "(rib rib?)" tests/36-fact.scm
```

Note that at the moment, only the `js` and `c` target are supported. And as the `(prefix ...)` option in the `(rvm-prim-generator-setup)` command doesn't work properlly yet, its better to use the `c` version. 