### PR TITLE
Remove bashism in makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -14,7 +14,7 @@ build-all:
 	done
 
 check:
-	@if [ "$$HOST" == "" ]; then \
+	@if [ "$$HOST" = "" ]; then \
 	  for host in $(HOSTS); do \
 	    echo "====================== TESTING HOST $$host"; \
 	    cd host/$$host; $(MAKE) check; cd ../..; \


### PR DESCRIPTION
Using = inside a [ … ] expression only works for some shells like bash. On some systems, make defaults to the POSIX shell and this rule won't work.

Alternativement, on pourrait dire `SHELL := bash`, mais j'ai l'impression que les autre scripts sont fait pour fonctionner sur le sh POSIX.