### PR TITLE
Addition of optional parameters

### DIFF
--- a/src/host/js/rvm.js
+++ b/src/host/js/rvm.js
@@ -83,6 +83,13 @@ if (nodejs) { // in nodejs? //node
 
 // VM
 
+// @@(feature (or error-msg debug) (use scm2str)
+halt = () => {
+	const error_msg = new Error(scm2str(pop()));
+	throw error_msg;
+}
+// )@@
+
 // build the symbol table
 
 pos = 0;

--- a/src/lib/max.scm
+++ b/src/lib/max.scm
@@ -477,6 +477,18 @@
         (proc (car lst))
         (for-each proc (cdr lst)))
       #f))
+(define (foo x y (z 65))
+  (putchar x)
+  (putchar y)
+  (putchar z))
+
+(foo 69 69 69) ; E E E
+(foo 69 69) ; E E A
+; (foo) ; error
+; (foo 69) ; error
+; (foo 69 69 69 69) ; error
+
+
 
 ;; First-class continuations.
 
@@ -897,6 +909,7 @@
 (define (list3 a b c) (cons a (list2 b c)))
 (define (list2 a b) (cons a (list1 b)))
 (define (list1 a) (cons a '()))
+(define (list . args) args)
 
 (define (comp-bind cte var expr body cont)
   (comp cte

--- a/src/lib/max.scm
+++ b/src/lib/max.scm
@@ -477,18 +477,6 @@
         (proc (car lst))
         (for-each proc (cdr lst)))
       #f))
-(define (foo x y (z 65))
-  (putchar x)
-  (putchar y)
-  (putchar z))
-
-(foo 69 69 69) ; E E E
-(foo 69 69) ; E E A
-; (foo) ; error
-; (foo 69) ; error
-; (foo 69 69 69 69) ; error
-
-
 
 ;; First-class continuations.
 

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1349,23 +1349,6 @@
             (expand-list (cdr exprs)))
       '()))
 
-(define (expand-opt-param-old param-name param-default vararg-name)
-  ; `((,param-name (if (null? ,vararg-name)
-  ;				  ,param-default
-  ;				  (let ((value (car ,vararg-name)))
-  ;					(set! ,vararg-name (cdr ,vararg-name))
-  ;					value))))
-
-  (list
-	(list param-name 
-		  (list 'if (list 'null? vararg-name)
-				(expand-expr param-default)
-				(list 'let (list (list 'value (list 'car vararg-name)))
-					  (list 'set! vararg-name (list 'cdr vararg-name))
-					  'value
-					  )
-				)
-		  )))
 
 (define (expand-opt-param param-name param-default vararg-name)
   ; `((,param-name (if (null? ,vararg-name)
@@ -1374,6 +1357,9 @@
   ;					(set! ,vararg-name (cdr ,vararg-name))
   ;					value))))
 
+  ;; If this part is not performant enough, replace the set! with a
+  ;; (vararg (if (eqv? vararg '()) '() (field1 vararg)))
+  ;; after every optional arg clause
   (list
 	(list param-name 
 		  (list 'if (list 'eqv? vararg-name '())

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1079,7 +1079,7 @@
 									(cons (expand-body (list (list 'let* opt-params-body 
 																   (expand-body (append (if variadic 
 																						  '() 
-																						  (list (list 'if (list 'pair? vararg-name) 
+																						  (list (list 'if (list 'eqv? (list 'field2 vararg-name) '0)
 																								'(error "To much arguments have been passed to the function."))))
 																						(cddr expr))))))
 										  '())))))))
@@ -1376,10 +1376,10 @@
 
   (list
 	(list param-name 
-		  (list 'if (list 'null? vararg-name)
+		  (list 'if (list 'eqv? vararg-name '())
 				(expand-expr param-default)
-				(list 'let (list (list 'value (list 'car vararg-name)))
-					  (list 'set! vararg-name (list 'cdr vararg-name))
+				(list 'let (list (list 'value (list 'field0 vararg-name)))
+					  (list 'set! vararg-name (list 'field1 vararg-name))
 					  'value
 					  )
 				)

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -642,33 +642,33 @@
                   (let* ((params (cadr expr))
                          (variadic (or (symbol? params) (not (eq? (last-item params) '()))))
                          (nb-params
-                            (if variadic
-                              (improper-length params)
-                              (length params)))
+                           (if variadic
+                             (improper-length params)
+                             (length params)))
                          (params 
                            (if variadic
                              (improper-list->list params '())
                              params)))
                     (rib const-op
                          (make-procedure
-                          (rib (+ (* 2 nb-params) (if variadic 1 0))
-                               0
-                               (comp-begin (ctx-cte-set
-                                             ctx
-                                             (extend params
-                                                     (cons #f
-                                                           (cons #f
-                                                                 (ctx-cte ctx)))))
-                                           (cddr expr)
-                                           tail))
-                          '())
+                           (rib (+ (* 2 nb-params) (if variadic 1 0))
+                                0
+                                (comp-begin (ctx-cte-set
+                                              ctx
+                                              (extend params
+                                                      (cons #f
+                                                            (cons #f
+                                                                  (ctx-cte ctx)))))
+                                            (cddr expr)
+                                            tail))
+                           '())
                          (if (null? (ctx-cte ctx))
-                             cont
-                             (add-nb-args
-                               ctx
-                               1
-                               (gen-call (use-symbol ctx 'close) 
-                                         cont))))))
+                           cont
+                           (add-nb-args
+                             ctx
+                             1
+                             (gen-call (use-symbol ctx 'close) 
+                                       cont))))))
 
                  ((eqv? first 'begin)
                   (comp-begin ctx (cdr expr) cont))
@@ -1036,53 +1036,53 @@
                                             #f)
                                           '())))))
 
-				 ((eqv? first 'lambda)
-				  (let* ((params (cadr expr)) 
-						 (opt-params '())
-						 (required-params '())
-						 (variadic (or (symbol? params) (not (eq? (last-item params) '()))))
-						 (nb-params (if variadic (improper-length params) (length params))))
-					;; Gather all optional params from the parameter list
-					(let loop ((i 0) (params params))
-					  (if (< i nb-params)
-						(let ((param (car params)))
-						  (cond 
-							((and (symbol? param) (null? opt-params)) 
-							 (set! required-params (append required-params (cons param '())))
-							 (loop (+ 1 i) (cdr params)))
+                 ((eqv? first 'lambda)
+                  (let* ((params (cadr expr)) 
+                         (opt-params '())
+                         (required-params '())
+                         (variadic (or (symbol? params) (not (eq? (last-item params) '()))))
+                         (nb-params (if variadic (improper-length params) (length params))))
+                    ;; Gather all optional params from the parameter list
+                    (let loop ((i 0) (params params))
+                      (if (< i nb-params)
+                        (let ((param (car params)))
+                          (cond 
+                            ((and (symbol? param) (null? opt-params)) 
+                             (set! required-params (append required-params (cons param '())))
+                             (loop (+ 1 i) (cdr params)))
 
-							((pair? param)
-							 (set! opt-params (append opt-params (cons param '()))) 
-							 (loop (+ 1 i) (cdr params)))
+                            ((pair? param)
+                             (set! opt-params (append opt-params (cons param '()))) 
+                             (loop (+ 1 i) (cdr params)))
 
-							(else (error "Cannot put non-optional arguments after optional ones.")))
-						  )
-						))
-					(if (null? opt-params)
-					  (cons 'lambda
-							(cons params
-								  (cons (expand-body (cddr expr))
-										'())))
-					  ;; Add the check for the optional params 
-					  (let ((vararg-name (if variadic (last-item params) '##vararg))
-							 (opt-params-body '()))
-						(if (pair? required-params)
-						  (set-cdr! (list-tail required-params (- (length required-params) 1)) vararg-name)
-						  (set! required-params vararg-name)
-						)
-						(for-each
-						  (lambda (opt-param)
-							(set! opt-params-body (append opt-params-body (expand-opt-param (car opt-param) (cadr opt-param) vararg-name))))
-						  opt-params)
-						(cons 'lambda
-							  (cons required-params
-									(cons (expand-body (list (list 'let* opt-params-body 
-																   (expand-body (append (if variadic 
-																						  '() 
-																						  (list (list 'if (list 'eqv? (list 'field2 vararg-name) '0)
-																								'(error "To much arguments have been passed to the function."))))
-																						(cddr expr))))))
-										  '())))))))
+                            (else (error "Cannot put non-optional arguments after optional ones.")))
+                          )
+                        ))
+                    (if (null? opt-params)
+                      (cons 'lambda
+                            (cons params
+                                  (cons (expand-body (cddr expr))
+                                        '())))
+                      ;; Add the check for the optional params 
+                      (let ((vararg-name (if variadic (last-item params) '##vararg))
+                            (opt-params-body '()))
+                        (if (pair? required-params)
+                          (set-cdr! (list-tail required-params (- (length required-params) 1)) vararg-name)
+                          (set! required-params vararg-name)
+                          )
+                        (for-each
+                          (lambda (opt-param)
+                            (set! opt-params-body (append opt-params-body (expand-opt-param (car opt-param) (cadr opt-param) vararg-name))))
+                          opt-params)
+                        (cons 'lambda
+                              (cons required-params
+                                    (cons (expand-body (list (list 'let* opt-params-body 
+                                                                   (expand-body (append (if variadic 
+                                                                                          '() 
+                                                                                          (list (list 'if (list 'eqv? (list 'field2 vararg-name) '0)
+                                                                                                      '(error "To much arguments have been passed to the function."))))
+                                                                                        (cddr expr))))))
+                                          '())))))))
 
                  ((eqv? first 'let)
                   (let ((x (cadr expr)))
@@ -1352,24 +1352,24 @@
 
 (define (expand-opt-param param-name param-default vararg-name)
   ; `((,param-name (if (null? ,vararg-name)
-  ;				  ,param-default
-  ;				  (let ((value (car ,vararg-name)))
-  ;					(set! ,vararg-name (cdr ,vararg-name))
-  ;					value))))
+  ;                  ,param-default
+  ;                  (let ((value (car ,vararg-name)))
+  ;                    (set! ,vararg-name (cdr ,vararg-name))
+  ;                    value))))
 
   ;; If this part is not performant enough, replace the set! with a
   ;; (vararg (if (eqv? vararg '()) '() (field1 vararg)))
   ;; after every optional arg clause
   (list
-	(list param-name 
-		  (list 'if (list 'eqv? vararg-name '())
-				(expand-expr param-default)
-				(list 'let (list (list 'value (list 'field0 vararg-name)))
-					  (list 'set! vararg-name (list 'field1 vararg-name))
-					  'value
-					  )
-				)
-		  )))
+    (list param-name 
+          (list 'if (list 'eqv? vararg-name '())
+                (expand-expr param-default)
+                (list 'let (list (list 'value (list 'field0 vararg-name)))
+                      (list 'set! vararg-name (list 'field1 vararg-name))
+                      'value
+                      )
+                )
+          )))
 
 ;;;----------------------------------------------------------------------------
 
@@ -1464,7 +1464,7 @@
                     (let ((var (cadr expr)))
                       (let ((val (caddr expr)))
                         (if (in? var cte) ;; local var?
-                            (liveness val cte #f)
+                          (liveness val cte #f)
                             (begin
                               (if export-all? (add var))
                               (let ((g (live? var live-globals))) ;; variable live?

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -2526,7 +2526,6 @@
      ;; merge the compacted RVM code with the implementation of the RVM
      ;; for a specific target and minify the resulting target code.
 
-	 ; (step)
      (let* ((vm-source 
               (if (equal? _target "rvm")
                 #f

--- a/src/tests/38-optional-params.scm
+++ b/src/tests/38-optional-params.scm
@@ -1,0 +1,11 @@
+(define (foo x y (z 65))
+  (putchar x)
+  (putchar y)
+  (putchar z))
+
+(foo 69 69 69) ; E E E
+(foo 69 69) ; E E A
+; (foo) ; error
+; (foo 69) ; error
+; (foo 69 69 69 69) ; error
+

--- a/src/tests/38-optional-params.scm
+++ b/src/tests/38-optional-params.scm
@@ -46,6 +46,8 @@
 (barbar 70 71) ; F G
 (putchar 10)
 
+(barbar 70 71 72)
+
 ; (foo) ; error
 ; (foo 69) ; error
 ; (foo 69 69 69 69) ; error

--- a/src/tests/38-optional-params.scm
+++ b/src/tests/38-optional-params.scm
@@ -4,7 +4,48 @@
   (putchar z))
 
 (foo 69 69 69) ; E E E
+(putchar 10)
+
 (foo 69 69) ; E E A
+(putchar 10)
+
+(define (bar x (y 65) . z)
+  (putchar x)
+  (putchar y)
+  (putchar (if (null? z) 78 (car z))))
+
+(bar 69) ; E A N
+(putchar 10)
+
+(bar 69 70) ; E F N
+(putchar 10)
+
+(bar 69 70 71 66) ; E F G
+(putchar 10)
+
+(define sym 69)
+(define (baz (x sym))
+  (putchar x))
+
+(baz 66) ; B
+(putchar 10)
+
+(baz) ; E
+(putchar 10)
+
+(define (plus x (y 1))
+  (+ x y))
+
+(define (barbar y (x (plus 68)))
+  (putchar y)
+  (putchar x))
+
+(barbar 70) ; F E
+(putchar 10)
+
+(barbar 70 71) ; F G
+(putchar 10)
+
 ; (foo) ; error
 ; (foo 69) ; error
 ; (foo 69 69 69 69) ; error

--- a/src/tests/38-optional-params.scm
+++ b/src/tests/38-optional-params.scm
@@ -12,7 +12,7 @@
 (define (bar x (y 65) . z)
   (putchar x)
   (putchar y)
-  (putchar (if (null? z) 78 (car z))))
+  (putchar (if (eqv? z '()) 78 (field0 z))))
 
 (bar 69) ; E A N
 (putchar 10)
@@ -46,9 +46,19 @@
 (barbar 70 71) ; F G
 (putchar 10)
 
-(barbar 70 71 72)
-
+; (barbar 70 71 72) ; error
 ; (foo) ; error
 ; (foo 69) ; error
 ; (foo 69 69 69 69) ; error
 
+;;;options: -l empty
+;;;expected:
+;;;EEE
+;;;EEA
+;;;EAN
+;;;EFN
+;;;EFG
+;;;B
+;;;E
+;;;FE
+;;;FG


### PR DESCRIPTION
## The addition of optional parameters with the following syntax:
```scheme
(define (foo required1 required2 (opt1 default1) (opt2 default2))
    ...)
``` 
It also works with the variadic lambdas.

A test was added (test#38) to make sure this feature is working correctly and compliant with `-l empty` level of compilation.

Also, an error-message feature was added to the js rvm to make it easier to debug its output.