### PR TITLE
Rework RVM parsing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,8 @@ jobs:
         with:
           name: minify-exe
           path: src/scripts/minify
-  test_rvm:
+
+  rvm_generation_tests:
     runs-on: ubuntu-latest
     needs: compile_RSC
     steps:
@@ -83,7 +84,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
       - name: Download rsc.exe artifact into rsc-exe
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: rsc-exe
           path: src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,27 @@ jobs:
         with:
           name: minify-exe
           path: src/scripts/minify
+  test_rvm:
+    runs-on: ubuntu-latest
+    needs: compile_RSC
+    steps:
+      - name: Checkout the ribbit repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+      - name: Download rsc.exe artifact into rsc-exe
+        uses: actions/download-artifact@v2
+        with:
+          name: rsc-exe
+          path: src
+      - name: Set up permissions on rsc.exe
+        run: |
+          chmod +x src/rsc.exe
+      - name: Run test
+        run: |
+          cd src && make check-features
+
   py_rvm:
     runs-on: ubuntu-latest
     needs: compile_RSC

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ src/.vscode/tasks.json
 src/rvm-sizes.log
 **/tmp*
 src/scripts/minify
+src/.tests

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ src/.vscode/launch.json
 src/.vscode/tasks.json
 src/rvm-sizes.log
 **/tmp*
+src/scripts/minify

--- a/src/examples/rib_eater.scm
+++ b/src/examples/rib_eater.scm
@@ -7,10 +7,10 @@
 (define-feature 
   rib_eater
   (use scm2host)
-  (decl "collected_ribs = [];
-         function eat_rib(r) { collected_ribs.push(scm2host(r)); }")
-  (start "console.log('Rib eater is activated');")
-  (end "console.log('Here are my lovely eaten ribs (miam) : ', collected_ribs)"))
+  ((decl "collected_ribs = [];"
+         "function eat_rib(r) { collected_ribs.push(scm2host(r)); }")
+   (start "console.log('Rib eater is activated');")
+   (end "console.log('Here are my lovely eaten ribs (miam) : ', collected_ribs)")))
 
 (define-primitive 
   (eat rib)

--- a/src/host/asm/tests/60-primitives.scm
+++ b/src/host/asm/tests/60-primitives.scm
@@ -2,7 +2,7 @@
       "\tdd   prim_square\n")
 
 (define-feature square
-      (prims "
+  ((prims "
 prim_square: 
 %if FIX_TAG != 0
 \tdec LAST_ARG
@@ -14,8 +14,7 @@ prim_square:
 \tinc LAST_ARG
 %endif
 \tNBARGS(1)
-\tret"))
-
+\tret")))
 
 (##putchar (square 6))
 (##putchar 10)

--- a/src/host/hs/lib/prim-io.scm
+++ b/src/host/hs/lib/prim-io.scm
@@ -1,4 +1,6 @@
-(define-feature hs/io-handle (hs/foreign-type "    | RibHandle !Handle"))
+(define-feature 
+  hs/io-handle 
+  ((hs/foreign-type "    | RibHandle !Handle")))
 
 (define-primitive
   (##stdin-fd)

--- a/src/host/lua/rvm.lua
+++ b/src/host/lua/rvm.lua
@@ -144,7 +144,7 @@ local primitives = {
    prim2(quotient),                                  -- @@(primitive (##quotient x y))@@         
    getchar,                                          -- @@(primitive (##getchar))@@              
    prim1(putchar),                                   -- @@(primitive (##putchar c))@@            
-   prim1(os.exit)                                    -- @@(primitive (##exit n))@@               
+   prim1(os.exit),                                   -- @@(primitive (##exit n))@@
 -- )@@
 }
 

--- a/src/host/ml/rvm.ml
+++ b/src/host/ml/rvm.ml
@@ -251,7 +251,7 @@ module Primitives : PRIMITIVES = struct
       (*  )@@ *)
       prim0 (function () -> Integer (getchar ()));                                                                (* @@(primitive (##getchar))@@ *)
       prim1 (function Integer ch -> Integer (putchar ch) | _ -> invalid_arg "putchar argument must be Integer");  (* @@(primitive (##putchar x))@@ *)
-      prim1 (function Integer status -> exit status | _ -> invalid_arg "exit argument must be Integer")           (* @@(primitive (##exit x))@@ *)
+      prim1 (function Integer status -> exit status | _ -> invalid_arg "exit argument must be Integer");          (* @@(primitive (##exit x))@@ *)
   (*  )@@ *)
     |]
 end

--- a/src/lib/r4rs/control.scm
+++ b/src/lib/r4rs/control.scm
@@ -23,7 +23,7 @@
   ((host py)
    (define-feature
      ##apply
-     (decl
+     ((decl
 "def prim_apply():
  _arg = pop()
  f = pop()
@@ -35,7 +35,7 @@
  push(num_args) # @@(feature arity-check)@@
  return f
 
-"))
+")))
    (define-primitive
      (##apply f args)
      "prim_apply,"))

--- a/src/lib/r4rs/sys.scm
+++ b/src/lib/r4rs/sys.scm
@@ -1,7 +1,7 @@
 (cond-expand
   ((host js)
 
-   ;; (define-feature js/node/child-process (use) (decl "const child_p = require('child_process');\n"))
+   ;; (define-feature js/node/child-process (use) ((decl "const child_p = require('child_process');\n")))
 
    (define-primitive 
      (##cmd-line)
@@ -28,7 +28,7 @@
 
   ((host py)
 
-   (define-feature py/sys (use) (import "import os,sys"))
+   (define-feature py/sys (use) ((import "import os,sys")))
 
    (define-primitive 
      (##cmd-line)

--- a/src/makefile
+++ b/src/makefile
@@ -68,19 +68,21 @@ check-repl: rsc.exe
 check-pipeline: check
 check-all: check-pipeline check-fancy check-features check-bootstrap
 
-check-features:
+check-features: rsc.exe
 	@host="$${HOST:-js}"; \
-	for host_path in ./tests/hosts/*; do \
+	error=0; \
+	for host_path in ./tests/hosts/*.test; do \
 		options=`sed -n -e '/;;;options:/p' $$host_path | sed -e 's/^;;;options://'`; \
 	    nb_visible_original=`grep -c visible $$host_path`; \
 		nb_hidden_original=`grep -c hidden $$host_path`; \
 		echo "====================== TESTING FEATURE $$host_path (v:$$nb_visible_original, h:$$nb_hidden_original, options: '$$options')"; \
-		cmd="$${GSI} rsc.scm -t $$host $$options lib/empty.scm --rvm $$host_path -o .test-feature.REMOVE"; \
+		cmd="${RSC_COMPILER} -t $$host $$options lib/empty.scm --rvm $$host_path -o .test-feature.REMOVE"; \
 		$$cmd; \
 		nb_visible_after=`grep -c visible .test-feature.REMOVE;` \
 		nb_hidden_after=`grep -c hidden .test-feature.REMOVE`; \
-		if ! [[ "$$nb_visible_after" -eq "$$nb_visible_original" && "$$nb_hidden_after" -eq "0" ]] ; then \
-		    echo "Mismatch on visible/hidden."; \
+		if [ "$$nb_visible_after" != "$$nb_visible_original" ] || [ "$$nb_hidden_after" != "0" ] ; then \
+		  error=1; \
+		  echo "Mismatch on visible/hidden."; \
 			echo "  Visible expected : $$nb_visible_original "; \
 			echo "  Visible got      : $$nb_visible_after "; \
 			echo "  Hidden expected  : 0 (found $$nb_hidden_original in original file)"; \
@@ -92,9 +94,12 @@ check-features:
 			echo ""; \
 			echo "--- Generated file ($$cmd) :"; \
 			echo ""; \
-	        cat .test-feature.REMOVE; \
+	    cat .test-feature.REMOVE; \
 		fi; \
-	done
+	done; \
+	if [ $$error -eq 1 ]; then \
+	  exit 1; \
+	fi;
 
 check-bootstrap: rsc.exe
 	@UP_CASE="(##vector-set! ##main-readtable 1 'upcase)"; \

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -161,7 +161,7 @@
      (call-with-output-string
       (lambda (port)
         (parameterize ((current-output-port port))
-                      (thunk))))))
+          (thunk))))))
 
   (else
 
@@ -536,92 +536,8 @@
           (string->list str))
         (reverse final)))
 
-    (define (pp-return foo . x)
-      (let ((r (apply foo x)))
-        (pp r)
-        r))))
+    ))
 
-
-
-(define (display-return foo . x)
-  (let ((r (apply foo x)))
-    (display r)
-    (newline)
-    r))
-;;;----------------------------------------------------------------------------
-
-(define (display-rib rib depth)
-  (if (> depth 0)
-    (begin
-      (display "[")
-      (cond ((not (rib? rib))
-             (display rib))
-            ((rib? (field0 rib))
-             (display-rib (field0 rib) (- depth 1)))
-            (else
-              (display (field0 rib))))
-      (display " ")
-      (cond ((not (rib? rib))
-             (display rib))
-            ((rib? (field1 rib))
-             (display-rib (field1 rib) (- depth 1)))
-            (else
-              (display (field1 rib))))
-      (display " ")
-      (cond ((not (rib? rib))
-             (display rib))
-            ((rib? (field2 rib))
-             (display-rib (field2 rib) (- depth 1)))
-            (else
-              (display (field2 rib))))
-      (display "]"))
-    (display "...")))
-
-
-;;;------------------------------------------------------------------------------
-
-(define predefined (list '##rib 'false 'true 'nil)) ;; predefined symbols
-
-(define default-primitives-lst
-`((##rib         0  x  y  z)
-  (##id          1  x)
-  (##arg1        2  x  y)
-  (##arg2        3  x  y)
-  (##close       4  rib)
-  (##rib?        5  o)
-  (##field0      6  x)
-  (##field1      7  x)
-  (##field2      8  x)
-  (##field0-set! 9  x  v)
-  (##field1-set! 10 x  v)
-  (##field2-set! 11 x  v)
-  (##eqv?        12 o1 o2)
-  (##<           13 x  y)
-  (##+           14 x  y)
-  (##-           15 x  y)
-  (##*           16 x  y)
-  (##quotient    17 x  y)
-  (##getchar     18 )
-  (##putchar     19 c)
-  (##exit        20 code)))
-
-
-(define (default-primitive-index prim)
-  (cadr (assoc prim default-primitives-lst)))
-
-(define default-primitives
-  (map
-    (lambda (p) `(primitive () ,(cons (car p) (cddr p)) (@@index ,(cadr p))))
-    default-primitives-lst))
-
-
-(define jump/call-op 'jump/call)
-(define set-op       'set)
-(define get-op       'get)
-(define const-op     'const)
-(define if-op        'if)
-
-;;;----------------------------------------------------------------------------
 
 ;;; Ribs emulation as vectors for other implementations than Ribbit. 
 (cond-expand
@@ -666,16 +582,52 @@
 (define (c-procedure-code proc) (c-rib-oper proc))
 (define (c-procedure-env proc) (c-rib-opnd proc))
 
+;;;------------------------------------------------------------------------------
+
+(define predefined (list '##rib 'false 'true 'nil)) ;; predefined symbols
+
+(define default-primitives-lst
+`((##rib         0  x  y  z)
+  (##id          1  x)
+  (##arg1        2  x  y)
+  (##arg2        3  x  y)
+  (##close       4  rib)
+  (##rib?        5  o)
+  (##field0      6  x)
+  (##field1      7  x)
+  (##field2      8  x)
+  (##field0-set! 9  x  v)
+  (##field1-set! 10 x  v)
+  (##field2-set! 11 x  v)
+  (##eqv?        12 o1 o2)
+  (##<           13 x  y)
+  (##+           14 x  y)
+  (##-           15 x  y)
+  (##*           16 x  y)
+  (##quotient    17 x  y)
+  (##getchar     18 )
+  (##putchar     19 c)
+  (##exit        20 code)))
+
+(define default-primitives
+  (map
+    (lambda (p) `(primitive () ,(cons (car p) (cddr p)) (@@index ,(cadr p))))
+    default-primitives-lst))
+
+
+(define jump/call-op 'jump/call)
+(define set-op       'set)
+(define get-op       'get)
+(define const-op     'const)
+(define if-op        'if)
+
+;;;----------------------------------------------------------------------------
+
+
 
 ;;; -----------------------------------------------
 ;;; ==================== DEBUG ====================
 ;;; -----------------------------------------------
-
-(define (display-return foo . x)
-  (let ((r (apply foo x)))
-    (display r)
-    (newline)
-    r))
 
 ;; Displays a rib to stdout given a depth
 (define (display-rib rib depth)
@@ -705,6 +657,17 @@
       (display "]"))
     (display "...")))
 
+
+(define (pp-return foo . x)
+  (let ((r (apply foo x)))
+    (pp r)
+    r))
+
+(define (display-return foo . x)
+  (let ((r (apply foo x)))
+    (display r)
+    (newline)
+    r))
 
 ;;; -----------------------------------------------
 ;;; ==================== UTILS ====================
@@ -2407,7 +2370,7 @@
                           (use  (caddr expr)))
 
                       (if (not (eq? (car use) 'use))
-                        (error "Ill-formed define-feature construct. Expected 'use' keyword." use))
+                        (error "Ill-formed define-primitive construct. Expected 'use' keyword." use))
 
                       (if (or (live-env-live-feature? env name) (live-env-live? env name))
                         (begin

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1202,7 +1202,6 @@
 ;;       call-rib-ok?)))
 
 (define (is-call? ctx name cont)
-;;  (let ((xxx
   (and (rib? cont)
        (if (arity-check? ctx name)
            (and (eqv? (c-rib-oper cont) const-op)
@@ -1211,7 +1210,6 @@
                 (eqv? (c-rib-opnd (c-rib-next cont)) name))
            (and (eqv? (c-rib-oper cont) jump/call-op)
                 (eqv? (c-rib-opnd cont) name)))))
-;;) (pp (list xxx (arity-check? ctx name)(eqv? (c-rib-oper cont) jump/call-op) (eqv? (c-rib-opnd cont) name)cont)) xxx))
 
 (define (gen-noop ctx cont)
   (if (is-call? ctx '##arg1 cont)
@@ -2153,7 +2151,6 @@
 
 ;; Other usefull procedures
 
-
 (define (live-env-reset-defs live-env)
 
   (define (reset-defs lst)
@@ -2336,6 +2333,13 @@
                       (if (eval-feature feature-expr (live-env-features env))
                         (liveness (caddr expr) cte #f)
                         (liveness (cadddr expr) cte #f))))
+
+                   ;((eqv? first 'use-feature)
+                   ; (let ((feature-lst (cdr expr)))
+                   ;   (for-each 
+                   ;     (lambda (x) (live-env-add-feature! env x))
+
+
 
                    (else
                      ;; Calls in first position create a binding, thus needing ##arg2
@@ -2814,9 +2818,6 @@
                       (loop4 (cdr symbols*))
                       (cons syms symbols*)))))))))))
 
-                      ;; (encode-stream
-                      ;; proc
-                      ;; encoding)
 (define (get-maximal-encoding encodings stats encoding-size)
 
     (define encoding-size-counter encoding-size)
@@ -2879,7 +2880,10 @@
     (define (recalculate)
       (for-each
         (lambda (encoding)
-          (if (and (pair? encoding) (table-ref stats (car encoding) #f) (table-ref (table-ref stats (car encoding)) (cadr encoding) #f)) ;; FIXME: this check is needed because the instruction might be missing
+          (if (and (pair? encoding) 
+                   (table-ref stats (car encoding) #f) 
+                   ;; FIXME: this check is needed because the instruction might be missing
+                   (table-ref (table-ref stats (car encoding)) (cadr encoding) #f)) 
             (table-set!
               running-sums
               encoding
@@ -3097,73 +3101,6 @@
     (list (length stream) (length return) return)))
 
 
-
-
-
-;(define (encode-lzss-on-two-bytes stream bit-header length-header offset-header encoding-size host-config)
-;  ;; assuming tag is all 1
-;  (define header-tag (if (eqv? bit-header 2) 192 128))
-;
-;  ;(define encoding-size/2 (quotient encoding-size 2))
-;
-;  (define (encode encoded-stream tail)
-;    (if (pair? encoded-stream)
-;      (let ((code (car encoded-stream)))
-;        (encode
-;          (cdr encoded-stream)
-;          (cond
-;            ((pair? code)
-;             (let* ((offset (car code))
-;                    (len (cadr code))
-;                    (first-byte
-;                      (+
-;                        header-tag
-;                        (* (- len 3) (arithmetic-shift 1 (- offset-header 8)))
-;                        (arithmetic-shift offset -8)))
-;                    (second-byte
-;                      (bitwise-and offset 255)))
-;               ;(pp (list code first-byte second-byte))
-;               `(,first-byte
-;                 ,second-byte
-;                 .
-;                 ,tail)))
-;            (else
-;              (cons
-;                code
-;                tail)))))
-;      tail))
-;
-;  (if (not (eqv? (+ bit-header length-header offset-header) 16))
-;    (error "Bit header, length header and offset header must add up to 16"))
-;
-;  (let* ((encoded-stream
-;           (LZSS
-;             stream
-;             (- (arithmetic-shift 1 offset-header) 1)
-;             (- (arithmetic-shift 1 length-header) 1)
-;             encoding-size
-;             (lambda (x) (if (pair? x) 2 1))))
-;         (return (encode
-;                   encoded-stream
-;                   '()))
-;         (dec (decompress-lzss-2b
-;                return
-;                bit-header
-;                length-header
-;                offset-header)))
-;
-;;    (pp (map list dec encoded-stream))
-;;    (pp (length dec))
-;;    (pp (length encoded-stream))
-;;    (pp (filter (lambda (x) (not (equal? (car x) (cadr x)))) (map list dec encoded-stream)))
-;
-;    (if (equal? dec
-;                encoded-stream)
-;      (display "... ensuring that decompression works ...")
-;      (error "Decompression failed"))
-;    return))
-
-
 (define (encode-lzss-with-tag stream encoding-size host-config)
 
   (define encoding-size/2 (quotient encoding-size 2))
@@ -3255,12 +3192,6 @@
     (list tag 0))))
 
 
-
-
-
-
-
-
 ;; Inspired from the section 2.6.4 of https://ir.canterbury.ac.nz/bitstream/handle/10092/8411/bell_thesis.pdf?sequence=1&isAllowed=y
 ;;
 ;;   cost-func : function that calculates cost of encoding a value. A value can be a backward pointer
@@ -3320,7 +3251,6 @@
             (car matched-matching)
             (append
               (if (and (eqv? (car stream) (car match))
-                       ;(pair? (cdr match))
                        (< index already-encoded-size))
                 (list
                   (list
@@ -3452,14 +3382,9 @@
               (if (number? key)
                 (string-append " : " (number->string value))
                 "")
-
               " [ "
               (number->string int-value)
-              " bytes ]"
-
-
-              )
-            )
+              " bytes ]"))
           (newline)
           (if (table? value)
             (display-stats-aux
@@ -3548,8 +3473,7 @@
 
 (define (encoding-optimal-order encoding)
   (define order
-    '(
-      (jump int short)  ; 0
+    '((jump int short)  ; 0
       (jump int long)   ; 1
       (jump sym short)  ; 2
       (jump sym long)   ; 3
@@ -3584,8 +3508,6 @@
   (host-config-feature-add! host-config 'encoding/optimal/sizes (map caddr encoding))
   (host-config-feature-add! host-config 'encoding/optimal/start (map cadr encoding)))
 
-
-
 (define (encode-hyperbyte stream)
   (let loop ((stream stream) (result '()))
     (if (pair? stream)
@@ -3594,7 +3516,6 @@
               (cons (+ (* 16 (car stream)) (cadr stream)) result))
         (cons (car stream) result))
       result)))
-
 
 (define (encode proc exports host-config byte-stats encoding-name byte-base)
 
@@ -3608,7 +3529,8 @@
   (define size-base-min 7)
   (define size-base-max 13)
 
-  (define (ribn-base) (- byte-base compression-range-size))
+  (define (ribn-base) 
+    (- byte-base compression-range-size))
 
   ;; state
   (let ((encoding      #f) ;; chosen encoding
@@ -3761,30 +3683,6 @@
       ;; Dispatch logic
       (p/enc-const) ;; always encode constants
 
-#|
-      (if compression/2b?
-        (begin
-          (if (< (- encoding-size compression-range-size) 0)
-            (error "Too many codes reserved for 2b-compression"))
-          (set! encoding-size (- encoding-size compression-range-size))))
-
-
-          ;(if (not (eqv? encoding-size 256))
-          ;  (error "2b compression only works with 256 bytes encoding"))
-          ;(cond
-          ;  ((eqv? compression/2b/bits 1)
-          ;   (set! encoding-size 192))
-          ;  ((eqv? compression/2b/bits 2)
-          ;   (set! encoding-size 128))
-          ;  (else
-          ;    (error "2b compression only works with 1 or 2 bits")))))
-
-      (if hyperbyte?
-        (begin
-          (if (not (eqv? encoding-size 256))
-            (error "Hyperbyte only works with 256 bytes encoding"))
-          (set! encoding-size 16)))
-|#
       ;; Choose encoding
       (set! encoding
         (cond
@@ -4431,55 +4329,6 @@
       base
       parsed-file)))
 
-;; (define (next-line last-new-line)
-;;   (let loop ((cur last-new-line) (len 0))
-;;     (if (or (not (pair? cur)) (eqv? (car cur) 10)) ;; new line
-;;       (begin
-;;         ;(pp (list->string* last-new-line (+ 1 len)) )
-;;         (cons (and (pair? cur) (cdr cur))
-;;               (if (not (pair? cur))
-;;                 len
-;;                 (+ 1 len))))
-;;       (loop (cdr cur) (+ len 1)))))
-
-;; FIXME: Remove
-;; (define (detect-macro line len)
-;;   (let loop ((cur line) (len len) (start #f) (macro-len 0))
-;;     (if (<= len 2)
-;;       (if start  ;; NOTE: start is not the value '#t, it is the start of the macro
-;;         (cons
-;;           'start
-;;           (cons start
-;;                 (+ 1 macro-len)))
-;;         (cons 'none '()))
-;;       (cond
-;;         ((and (eqv? (car cur) 64)     ;; #\@
-;;               (eqv? (cadr cur) 64)    ;; #\@
-;;               (eqv? (caddr cur) 40))  ;; #\(
-;;          (if start
-;;            (error "cannot start 2 @@\\( on the same line")
-;;            (loop (cdddr cur)
-;;                  (- len 3)
-;;                  cur
-;;                  3)))
-;;         ((and (eqv? (car cur)  41)    ;; #\)
-;;               (eqv? (cadr cur) 64)    ;; #\@
-;;               (eqv? (cadr cur) 64))   ;; #\@
-;;          (if start
-;;            (cons
-;;       [2] === 3       'start-end ;; type
-;;              (cons
-;;                start
-;;                (+ 3 macro-len)))
-;;            (cons
-;;              'end ;; type
-;;              '())))
-;;         (else
-;;           (loop (cdr cur)
-;;                 (- len 1)
-;;                 start
-;;                 (if start (+ macro-len 1) macro-len)))))))
-
 (define (list-prefix? prefix lst)
   (if (pair? prefix)
     (if (pair? lst)
@@ -4569,8 +4418,8 @@
              (next-section
                (if (equal? cur-section "")
                  cur-line
-                 (string-append cur-section "\n" cur-line)))
-             )
+                 (string-append cur-section "\n" cur-line))))
+        
         (case macro-type
           ((none)
            (loop (cdr lines) parsed-file next-section))
@@ -4601,75 +4450,6 @@
           (else
            (error "Unknown macro type" macro-type))))
       (reverse `((str ,cur-section) . ,parsed-file)))))
-
-
-
-
-
-;;
-;; (define (parse-host-file cur-line)
-;;   (let loop ((cur-line cur-line)
-;;              (parsed-file '())
-;;              (start-len 0)
-;;              (start-line cur-line))
-;;     (if (pair? cur-line)
-;;       (let* ((next-line-pair (next-line cur-line))
-;;              (cur-end (car next-line-pair))
-;;              (cur-len (cdr next-line-pair))
-;;              (macro-pair (detect-macro (list->string* cur-line (length cur-line))))
-;;              (macro-type (car macro-pair))
-;;              (macro-args (cdr macro-pair))
-;;              (parsed-file
-;;                (cond
-;;                  ((eqv? macro-type 'end) ;; include last line
-;;                   (cons `(str ,(list->string* start-line (+ cur-len start-len))) parsed-file))
-;;                  ((eqv? start-len 0)
-;;                   parsed-file)
-;;                  ((or (eqv? macro-type 'start)
-;;                       (eqv? macro-type 'start-end))
-;;                   (cons `(str ,(list->string* start-line start-len)) parsed-file))
-;;                  (else
-;;                    parsed-file))))
-;;
-;;         (pp (list->string* cur-line (length cur-line)))
-;;         (pp macro-pair)
-;;         (cond
-;;           ((eqv? macro-type 'end)
-;;            (cons cur-end
-;;                  (reverse parsed-file)))
-;;           ((eqv? macro-type 'none)
-;;            (loop cur-end parsed-file (+ cur-len start-len) start-line))
-;;           ((eqv? macro-type 'start)
-;;            (let* ((macro (car macro-args))
-;;                   (macro-len (cdr macro-args))
-;;                   (macro-string (list->string* (cddr macro) (- macro-len 2)))
-;;                   (macro-sexp (read (open-input-string (string-append macro-string ")"))))
-;;                   (body-pair (parse-host-file cur-end))
-;;                   (body-cur-end (car body-pair))
-;;                   (body-parsed  (cdr body-pair))
-;;                   (head `(@@head ,(list->string* cur-line cur-len)))
-;;                   (body `(@@body ,body-parsed)))
-;;              (loop body-cur-end
-;;                    (cons `(,@macro-sexp ,head ,body) parsed-file)
-;;                    0
-;;                    body-cur-end)))
-;;           ((eqv? macro-type 'start-end)
-;;            (let* ((macro (car macro-args))
-;;                   (macro-len (cdr macro-args))
-;;                   (macro-string (list->string* (cddr macro) (- macro-len 4)))
-;;                   (macro-sexp (read (open-input-string macro-string)))
-;;                   (head-parsed (list->string* cur-line cur-len))
-;;                   (body (cons '@@body `(((str ,head-parsed)))))
-;;                   (head (cons '@@head (list head-parsed))))
-;;              (loop
-;;                cur-end
-;;                (cons `(,@macro-sexp ,head ,body) parsed-file)
-;;                0
-;;                cur-end)))
-;;           (else (error "Unknown macro-type"))))
-;;
-;;       (reverse (cons `(str ,(list->string* start-line start-len)) parsed-file)))))
-;;
 
 (define (unique-aux lst1 lst2)
   (if (pair? lst1)
@@ -4963,7 +4743,6 @@
            (vector-ref proc-exports-and-features 1))
          (host-config
            (vector-ref proc-exports-and-features 2))
-
          (encode*
           (lambda (byte-base)
             (let ((input
@@ -5240,7 +5019,6 @@ EXAMPLE
 `rsc -t c -l r4rs source.scm -o output.c -x run-output.exe -m -v`
 This command compiles `source.scm` to C with verbosity set to 1 and minification enabled. 
 The output is written to output.c, with an executable compiled to run-output.exe (with gcc).")
-
 
   (let ((verbosity 0)
         (debug-info '())

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -611,7 +611,7 @@
 
 (define default-primitives
   (map
-    (lambda (p) `(primitive () ,(cons (car p) (cddr p)) (@@index ,(cadr p))))
+    (lambda (p) `(primitive () ,(cons (car p) (cddr p)) (use) (@@index ,(cadr p))))
     default-primitives-lst))
 
 

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1437,7 +1437,7 @@
         (display "*** Code expansion: \n")
         (pp expansion)))
 
-    (if (>= verbosity 3)
+    (if (or (>= verbosity 3) (memq 'hash-table debug-info))
       (begin
         (display "*** hash-consing table: \n")
         (pp
@@ -2248,7 +2248,6 @@
            (for-each add-val (vector->list val)))))
 
   (define (liveness expr cte top?)
-
 
     (cond ((symbol? expr)
            (if (in? expr cte) ;; local var?
@@ -5023,7 +5022,8 @@ DEBUGING OPTIONS
   Set verbosity level. Multiple 'v's increase verbosity.
 
   `-di`, `--debug-info INFO`
-  Add debug information. Info can be any of : `expansion`, `rvm-code`, `exports` and `host-config`.
+  Displays debug information to stdout.
+  Info can be any of : `expansion`, `rvm-code`, `hash-table`, `exports` and `host-config`.
 
   `-ps`, `--progress-status`
   Show progress status during compilation.

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1,9 +1,9 @@
 #!/usr/bin/env gsi
 ;;!#;; satisfy guile
 
-;;; Ribbit Scheme compiler.
+;;; The Ribbit Scheme Compiler (rsc). This file is distributed under the 
+;;; terms of the BSD 3-Clause License. See the file LICENSE for details.
 
-;;;----------------------------------------------------------------------------
 ;;;----------------------------------------------------------
 ;;;================== COMPATIBILITY LAYER ===================
 ;;;----------------------------------------------------------

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -4969,6 +4969,12 @@
              (report-first-status
                "Parsing host file"
                (parse-host-file vm-source '()))))
+         (_ (if (memq 'host-expansion debug-info)
+              (begin
+                (display "*** HOST FILE EXPANSION: ")
+                (newline)
+                (pp host-file)
+                (exit))))
 
          (encoding-name (if (equal? encoding-name "auto")
                             (let* ((available-features (extract-feature-names host-file))
@@ -5070,7 +5076,7 @@ DEBUGING OPTIONS
 
   `-di`, `--debug-info INFO`
   Displays debug information to stdout.
-  Info can be any of : `expansion`, `rvm-code`, `hash-table`, `exports` and `host-config`.
+  Info can be any of : `host-expansion` `expansion`, `rvm-code`, `hash-table`, `exports` and `host-config`.
 
   `-ps`, `--progress-status`
   Show progress status during compilation.

--- a/src/tests/03-features/00-activate-feature.scm
+++ b/src/tests/03-features/00-activate-feature.scm
@@ -1,0 +1,13 @@
+(if-feature activate-me
+  (display "activate-me is activated\n")
+  (display "activate-me is not activated\n"))
+
+(if-feature deactivate-me
+  (display "deactivate-me is activated\n")
+  (display "deactivate-me is not activated\n"))
+
+;;;run: -l max -f+ activate-me -f- deactivate-me
+;;;run: -l max -f= activate-me #t -f= deactivate-me #f
+;;;expected:
+;;;activate-me is activated
+;;;deactivate-me is not activated

--- a/src/tests/03-features/01-use-feature.scm
+++ b/src/tests/03-features/01-use-feature.scm
@@ -1,0 +1,37 @@
+(if-feature activate-me
+  (display "activate-me is activated\n")
+  (display "activate-me is not activated\n"))
+
+(if-feature deactivate-me
+  (display "deactivate-me is activated\n")
+  (display "deactivate-me is not activated\n"))
+
+(if-feature activate-me2
+  (display "activate-me2 is activated\n")
+  (display "activate-me2 is not activated\n"))
+
+(if-feature deactivate-me2
+  (display "deactivate-me2 is activated\n")
+  (display "deactivate-me2 is not activated\n"))
+
+(use-feature 
+  deactivate-me 
+  activate-me)
+
+(define (foo x)
+  (use-feature activate-me2)
+  x)
+
+;; should get eliminated by liveness analysis
+(define (bar x) 
+  (use-feature deactivate-me2)
+  x)
+
+(foo 42)
+
+;;;run: -l max -f+ activate-me -f- deactivate-me
+;;;expected:
+;;;activate-me is activated
+;;;deactivate-me is not activated
+;;;activate-me2 is activated
+;;;deactivate-me2 is not activated

--- a/src/tests/hosts/02-primitives.test
+++ b/src/tests/hosts/02-primitives.test
@@ -10,11 +10,11 @@ hidden
 hidden
 // )@@
 hidden
-// @@(primitive (prim1) (other prop)
+// @@(primitive (prim1)
 visible
 // )@@
 hidden
-// @@(primitive (prim2) (hey there)
+// @@(primitive (prim2)
 visible
 // )@@
 hidden

--- a/src/tests/hosts/02-primitives.test
+++ b/src/tests/hosts/02-primitives.test
@@ -2,7 +2,7 @@
 visible
 // @@(primitives (gen body)
 hidden
-// @@(primitive (rib a b c)
+// @@(primitive (##rib a b c)
 visible
 // )@@
 hidden

--- a/src/tests/hosts/03-use-primitives.test
+++ b/src/tests/hosts/03-use-primitives.test
@@ -9,7 +9,7 @@ visible
 visible
 // @@(primitives (gen body)
 hidden
-// @@(primitive (rib a b c)
+// @@(primitive (##rib a b c)
 visible
 // )@@
 // @@(primitive (prim0 x y) (use not-used)

--- a/src/tests/hosts/03-use-primitives.test
+++ b/src/tests/hosts/03-use-primitives.test
@@ -16,11 +16,11 @@ visible
 hidden
 // )@@
 hidden
-// @@(primitive (prim1) (other prop)
+// @@(primitive (prim1)
 visible
 // )@@
 hidden
-// @@(primitive (prim2) (hey there) (use used)
+// @@(primitive (prim2) (use used)
 visible
 // )@@
 hidden

--- a/src/tests/hosts/05-inline-primitives.test
+++ b/src/tests/hosts/05-inline-primitives.test
@@ -2,7 +2,7 @@
 
 //@@(primitives (gen body)
 hidden
-visible //@@(primitive (rib a b c))@@
+visible //@@(primitive (##rib a b c))@@
 hidden
 visible //@@(primitive (activated))@@
 hidden 

--- a/src/tests/hosts/README.md
+++ b/src/tests/hosts/README.md
@@ -1,0 +1,23 @@
+# Host tests
+
+## Rationale
+
+Instead of testing **scheme** code, host tests make sure that the compiler generates
+**a valid RVM** according to meta information inside of it. This includes feature, replace,
+primitive and other types of meta information. This meta information is annotated with 
+`@@(` and `)@@` tags.
+
+## How to run
+To run those tests, go into the [src](../src) directory and run : 
+
+```
+HOST={your host} make check-feature
+```
+
+## Inner workings
+
+These test works like this :
+ - First, a script counts the number of `visible` and `hidden` tags inside the test.
+ - Then, the test file (template rvm) is passed to the compiler with the `--rvm` test
+ - The output is checked to make sure that the `visible` tags are still present and that the `hidden` tags got removed
+


### PR DESCRIPTION
# Rationale

RVM's parsing relied on tags inside the "intermediate representation" such as `@@body`. This was not perfect, now the intermediate representation of RVM's is cleaner with a proper syntax (see `parse-host-file`) function inside of the `rsc.scm` file.

Also, the syntax for `define-feature` was ambiguous because of the `use` keyword. It was moved from : 
```
;; old syntax
(define-feature <feature-name> [<use-clause] <location-code pair> ...)
```
to :
```
;; new syntax
(define-feature <feature-name> [<use-clause>] (<location-code pair> ...))
```

Now `define-feature` looks more like a scheme `let`.

# Changes
- Rework the host parsing
- Adds tests for rvm with visible/hidden tags
- Changes the syntax of `define-feature`