### PR TITLE
Quick fix for crash when using "rvm" host

### DIFF
--- a/src/lib/r4rs/control.scm
+++ b/src/lib/r4rs/control.scm
@@ -3,7 +3,12 @@
 (##include-once "./pair-list.scm")
 
 ;; import apply primitives from host/<host>/lib/prim-apply.scm
-(##include-once (ribbit "prim-apply"))
+(cond-expand
+  ((host rvm)
+   ;; Skip rvm host (spitting out the ribn)
+   (begin))
+  (else
+    (##include-once (ribbit "prim-apply"))))
 
 
 ;; Control features (R4RS section 6.9).

--- a/src/lib/r4rs/io.scm
+++ b/src/lib/r4rs/io.scm
@@ -6,9 +6,14 @@
 (##include-once "./control.scm")
 (##include-once "./char.scm")
 
-;; import io primitives from host. 
+;; import io primitives from host.
 ;; They can be found inside of host/<host>/lib/prim-io.scm
-(##include-once (ribbit "prim-io"))
+(cond-expand
+  ((host rvm)
+   ;; Skip rvm host (spitting out the ribn)
+   (begin))
+  (else
+    (##include-once (ribbit "prim-io"))))
 
 ;; ---------------------- EOF & TYPES ---------------------- ;;
 


### PR DESCRIPTION
# Context

See #79. The `rvm` target makes `rsc.scm` crash. This is a quickfix, but the "rvm" target should be added to the CI to avoid these kind of crash again. This should be done in #82 