### PR TITLE
Remove default behavior of repl popup

### DIFF
--- a/src/lib/r4rs/tc.scm
+++ b/src/lib/r4rs/tc.scm
@@ -8,8 +8,11 @@
 (define (##tc-error . msgs)
   (map ##ntc-display msgs)
   (newline)
-  (set! ##dont-type-check-typechecking #f)
-  (repl))
+  (if-feature debug/repl
+    (begin
+      (set! ##dont-type-check-typechecking #f)
+      (repl))
+    (##exit 1)))
 
 (define ##dont-type-check-typechecking #f)
 

--- a/src/makefile
+++ b/src/makefile
@@ -128,10 +128,10 @@ clean:
 repl-asm.exe: rsc.exe
 	./rsc.exe -t asm -l r4rs lib/r4rs/repl.scm -e optimal -f+ compression/lzss/2b -f+ prim-no-arity -v -x repl-asm.exe
 
-../docs/repl_r4rs.js: rsc.exe host/js/* lib/r4rs/*
+../docs/repl_r4rs.js: rsc.exe host/js/* lib/r4rs/* scripts/minify
 	./rsc.exe -t js -f+ js/web -l r4rs -f+ compression/lzss/tag -m -e optimal lib/r4rs/repl.scm -f+ prim-no-arity -o ../docs/repl_r4rs.js
 
-../docs/repl_r4rs_tc.js: rsc.exe host/js/* lib/r4rs/*
-	./rsc.exe -t js -f+ js/web -l r4rs/tc -f+ compression/lzss/tag -m -e optimal lib/r4rs/repl.scm -f+ prim-no-arity -o ../docs/repl_r4rs_tc.js
+../docs/repl_r4rs_tc.js: rsc.exe host/js/* lib/r4rs/* scripts/minify
+	./rsc.exe -t js -f+ js/web -f+ debug/repl -l r4rs/tc -f+ compression/lzss/tag -m -e optimal lib/r4rs/repl.scm -f+ prim-no-arity -o ../docs/repl_r4rs_tc.js
 
 repl_r4rs: ../docs/repl_r4rs.js ../docs/repl_r4rs_tc.js


### PR DESCRIPTION
# Context 

After building the example code for #80, I realized that the REPL would show-up after an error. This behaviour is sometimes useful, for example, when using the web repl. But in most cases we want the program to crash with the relevant error. This PR moves the behaviour of spawning a repl behind the feature `debug/repl`. 