### PR TITLE
Time library!

### DIFF
--- a/src/host/c/lib/prim-timer.scm
+++ b/src/host/c/lib/prim-timer.scm
@@ -1,0 +1,62 @@
+;;; File: prim-timer.scm
+;; Implement the timer primitives. Timer primitives are used
+;; with the time library (see src/lib/time.scm)
+
+;; Add c global definitions to keep track of time
+(define-feature c/include-clock
+  ((import "#include <time.h>\n")))
+
+(define-feature c/timer/globals
+  (use c/include-clock)
+  ((decl "
+clock_t time_before;
+clock_t time_difference;
+")))
+
+(define-feature c/timer/gc-globals
+  (use c/include-clock)
+  ((decl "
+clock_t time_gc_before;
+clock_t time_gc_accumulated;
+int should_clock_gc = 0;
+int gc_invocations = 0;
+")
+   (gc-start "
+if(should_clock_gc == 1) {gc_invocations++;time_gc_before=clock();}
+")
+   (gc-end "
+if(should_clock_gc == 1) {time_gc_accumulated += clock()-time_gc_before; gc_invocations++;}
+")))
+
+
+;; Starts a new timer
+(define-primitive (##timer-start)
+  (use c/timer/globals c/timer/gc-globals)
+  "{
+  should_clock_gc = 1;
+  gc_invocations = 0;
+  time_gc_accumulated = 0;
+  time_before = clock();
+  push2(TAG_NUM(0), PAIR_TAG);
+  break;
+  }")
+
+;; Ends the timer
+(define-primitive (##timer-end)
+  (use c/time/globals c/time/gc-globals)
+  "{
+time_difference = clock() - time_before;
+should_clock_gc = 0;
+push2(TAG_NUM(0), PAIR_TAG);
+break;
+}")
+
+;; Display a timer in the format '2.623414 seconds (0.028148 seconds in GC, 3630 invocations)'
+(define-primitive (##timer-display)
+  (use c/time/globals c/time/gc-globals)
+  "{
+printf(\"%.6f seconds (%.6f seconds in GC, %d invocations)\\n\", ((double)time_difference) / CLOCKS_PER_SEC, ((double)time_gc_accumulated) / CLOCKS_PER_SEC, gc_invocations);
+push2(TAG_NUM(0), PAIR_TAG);
+break;
+}")
+

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -1028,9 +1028,9 @@ void run() {
             if (vari){
                 obj rest = NIL;
                 for(int i = 0; i < nargs; ++i){
-                    rest = TAG_RIB(alloc_rib(pop(), rest, s2));
-                    s2 = TAG(rest);
-                    TAG(rest) = PAIR_TAG;
+                    TEMP1 = s2;
+                    rest = TAG_RIB(alloc_rib(pop(), rest, PAIR_TAG));
+                    s2=TEMP1;
                 }
                 s2 = TAG_RIB(alloc_rib(rest, s2, PAIR_TAG));
             }

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -2,6 +2,8 @@
  * The Ribbit VM implementation in C
  */
 
+// @@(location import)@@
+
 // @@(feature debug
 #define DEBUG_I_CALL
 // )@@
@@ -256,6 +258,7 @@ obj check_access(obj x){
 #define STRING_TAG TAG_NUM(3)
 #define SINGLETON_TAG TAG_NUM(5)
 
+// @@(location decl)@@
 // the only three roots allowed
 obj stack = NUM_0;
 obj pc = NUM_0;
@@ -435,6 +438,7 @@ void mark(obj *o) { // Recursive version of marking phase
 #endif
 
 void gc() {
+  // @@(location gc-start)@@
 #ifdef DEBUG_GC
   printf("\t--GC called\n");
 #endif
@@ -457,6 +461,7 @@ void gc() {
   if (*alloc == _NULL){
     printf("Heap is full\n");
   }
+  // @@(location gc-end)@@
 }
 
 #else
@@ -496,6 +501,7 @@ void copy() {
 }
 
 void gc() {
+  // @@(location gc-start)@@
 #ifdef DEBUG_GC
   obj *from_space = (alloc_limit == heap_mid) ? heap_bot : heap_mid;
 
@@ -534,6 +540,7 @@ void gc() {
   fflush(stdout);
 
 #endif
+  // @@(location gc-end)@@
 }
 #endif // end of GC algorithms
 

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -172,7 +172,7 @@ typedef struct {
 
 // GC constants
 rib *heap_start;
-#define MAX_NB_OBJS 100000000 // 48000 is minimum for bootstrap
+#define MAX_NB_OBJS 100000 // 48000 is minimum for bootstrap
 #define SPACE_SZ (MAX_NB_OBJS * RIB_NB_FIELDS)
 #define heap_bot ((obj *)(heap_start))
 #ifdef MARK_SWEEP

--- a/src/host/c/rvm.c
+++ b/src/host/c/rvm.c
@@ -172,7 +172,7 @@ typedef struct {
 
 // GC constants
 rib *heap_start;
-#define MAX_NB_OBJS 100000 // 48000 is minimum for bootstrap
+#define MAX_NB_OBJS 1000000 // 48000 is minimum for bootstrap
 #define SPACE_SZ (MAX_NB_OBJS * RIB_NB_FIELDS)
 #define heap_bot ((obj *)(heap_start))
 #ifdef MARK_SWEEP

--- a/src/lib/time.scm
+++ b/src/lib/time.scm
@@ -1,0 +1,27 @@
+;; File: time.scm
+;;
+;; Library to compute the time functions take. This library
+;; assumes certain primitives to be available:
+;;
+;;  (##timer-start)   : Start an internal timer.
+;;  (##timer-end)     : Ends an internal timer.
+;;  (##timer-display) : Display to stdout the time elapsed between
+;;                      the call to ##start-timer and ##end-timer.
+;;
+;; These primitives have been chosen to limit the computations done
+;; inside scheme and to allow hosts to easily implement them.
+
+(##include-once (ribbit "define-macro"))
+
+;; Should be define for each host
+(##include-once (ribbit "prim-timer"))
+
+(define-macro (time thunk)
+  `(begin
+     (##timer-start)
+     ,thunk
+     (##timer-end)
+     (##timer-display)
+     0))
+
+

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -756,7 +756,7 @@
 (define (host-config-add-location! host-config location feature)
   (let ((location-ref (assoc location (host-config-locations host-config))))
     (if location-ref
-      (set-cdr! location-ref (append (cdr location-ref) feature))
+      (set-car! (cdr location-ref) (append (cadr location-ref) feature))
       (begin
         (host-config-locations-set! host-config (cons (list location feature) (host-config-locations host-config)))
         #t))))


### PR DESCRIPTION
# Context

This PR implements a library to time function calls. This can be used in any scheme program as such:

```
;; file time-test.scm
(time (+ 1 2)) ;; compute the time of the call to (+ 1 2)

(define (generate_garbage n)
  (if (< n 0)
      0
      (begin
        (list 1 2 3 4 5 6 7 8 9 10)
        (generate_garbage (- n 1)))))

(time (generate_garbage 1000000)) ;; Compute the time to generate a lot of garbage
```

To run it, use the `time` library (`-l time`):
```
$ ./rsc.exe -t c -l time -l r4rs time-test.scm -x time-test
$ ./time-test
0.000008 seconds (0.000000 seconds in GC, 0 invocations)
2.519294 seconds (0.024209 seconds in GC, 3626 invocations)
```

Hosts only need to implement three primitives to be able to use this library: `##timer-start`, `##timer-end` and `##timer-display`. See the file `src/lib/time.scm` for more details about the primitives or `src/host/c/lib/prim-timer.scm` for an example of primitive implementation in C.