### PR TITLE
Fix broken links in Ribbit's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ replacing `pro` with the target language.
 
 ### Other examples and tests
 
-For other examples and tests, you can look at the [examples](./src/examples) and [tests](./tests)
+For other examples and tests, you can look at the [examples](./src/examples) and [tests](./src/tests)
 directories.
 
 The makefile in the `src` directory has these make targets:

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -64,7 +64,7 @@ Note that all of these variables can be redefined in the command line. For examp
 HOST=c HOST_INTERPRETER="clang -o" TEST_TAGS=r4rs make check
 ```
 
-For an example of Makefile, see the [c host makefile](./../hosts/c/makefile).
+For an example of Makefile, see the [c host makefile](./../host/c/makefile).
 
 ## Test files
 

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -18,7 +18,7 @@ HOST=<host> make check-repl
 ```
 
 Where `<host>` is the host language you want to test. For example, <host> can be any of `c`, `js`, `asm`, `hs`, `py`. See
-the [front page](../README.md) for a list of all supported hosts.
+the [front page](./../../README.md) for a list of all supported hosts.
 
 # Test infrastructure
 
@@ -33,7 +33,7 @@ Given a host and test file, it will perform broadly the following steps:
    the `;;;input:` comment in the source code of the test.
 3. Compare the output of the target host file and the expected output specified in the test file with the `;;;expected` comment.
 
-For more details about the test runner, see the [test-runner](test-runner) script or continue reading.
+For more details about the test runner, see the [test-runner](./../run_test.sh) script or continue reading.
 
 ## Host Makefiles
 
@@ -64,7 +64,7 @@ Note that all of these variables can be redefined in the command line. For examp
 HOST=c HOST_INTERPRETER="clang -o" TEST_TAGS=r4rs make check
 ```
 
-For an example of Makefile, see the [c host makefile](../hosts/c/Makefile).
+For an example of Makefile, see the [c host makefile](./../hosts/c/makefile).
 
 ## Test files
 

--- a/src/tests/hosts/README.md
+++ b/src/tests/hosts/README.md
@@ -8,7 +8,7 @@ primitive and other types of meta information. This meta information is annotate
 `@@(` and `)@@` tags.
 
 ## How to run
-To run those tests, go into the [src](../src) directory and run : 
+To run those tests, go into the `src` directory and run : 
 
 ```
 HOST={your host} make check-feature


### PR DESCRIPTION
This PR fixes the broken links in the following files:
* `ribbit/README.md`
* `ribbit/src/tests/README.md`
* `ribbit/src/tests/hosts/README.md`