### PR TITLE
Addition to rsc.scm

### DIFF
--- a/src/bin/rsc
+++ b/src/bin/rsc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$(dirname $0)/../rsc.exe $@

--- a/src/lib/r4rs/sys.scm
+++ b/src/lib/r4rs/sys.scm
@@ -21,7 +21,7 @@
    (define-primitive
      (##shell-cmd cmd)
      (use js/node js/node/fs scm2list list2scm scm2str str2scm)
-     "prim1(cmd => str2scm(String(require('child_process').execSync(`sh -c '${scm2str(cmd)}'`)))),")
+     "prim1(cmd => str2scm((()=>{const r=(require('child_process').spawnSync(`${scm2str(cmd)}`,{shell:true}));return r.error ? `Error: ${String(r.stderr)}` : String(r.stdout);})())),")
 
    (define (list-dir dir-name) (##list-dir dir-name))
    (define (current-directory) (##current-directory)))

--- a/src/lib/r4rs/sys.scm
+++ b/src/lib/r4rs/sys.scm
@@ -21,7 +21,7 @@
    (define-primitive
      (##shell-cmd cmd)
      (use js/node js/node/fs scm2list list2scm scm2str str2scm)
-     "prim1(cmd => str2scm((()=>{const r=(require('child_process').spawnSync(`${scm2str(cmd)}`,{shell:true}));return r.error ? `Error: ${String(r.stderr)}` : String(r.stdout);})())),")
+     "prim1(cmd => str2scm((()=>{const r=(require('child_process').spawnSync(`${scm2str(cmd)}`,{shell:true}));return r.status!==0 ? `Error: ${String(r.stdout)}` : String(r.stdout);})())),")
 
    (define (list-dir dir-name) (##list-dir dir-name))
    (define (current-directory) (##current-directory)))

--- a/src/lib/resource/http.scm
+++ b/src/lib/resource/http.scm
@@ -3,4 +3,17 @@
 (##define-resource-reader
  http
  (lambda (resource-path)
-   (shell-cmd (string-append "curl --silent http://" resource-path))))
+   (let ((resource-path-real 
+           (if (string-prefix? "http:/" resource-path) 
+             (string-append "http://" (substring resource-path (string-length "http:/") (string-length resource-path)))
+             (string-append "http://" resource-path))))
+     (open-input-string (pipe-through (string-append "curl --silent " resource-path-real) "")))))
+
+(##define-resource-reader
+ https
+ (lambda (resource-path)
+   (let ((resource-path-real 
+           (if (string-prefix? "https:/" resource-path) 
+             (string-append "https://" (substring resource-path (string-length "https:/") (string-length resource-path)))
+             (string-append "https://" resource-path))))
+     (open-input-string (pipe-through (string-append "curl --silent " resource-path-real) "")))))

--- a/src/lib/resource/ipfs.scm
+++ b/src/lib/resource/ipfs.scm
@@ -3,4 +3,4 @@
 (##define-resource-reader
  ipfs
  (lambda (resource-path)
-   (shell-cmd (string-append "ipfs cat " resource-path))))
+   (open-input-string (pipe-through (string-append "ipfs cat " resource-path) ""))))

--- a/src/lib/resource/macros.scm
+++ b/src/lib/resource/macros.scm
@@ -1,3 +1,5 @@
+(##include-once (ribbit "define-macro"))
+
 (define-macro 
   (##define-resource-reader name reader)
   (add-resource-str-reader!

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -1828,7 +1828,7 @@
                       mtx)
                     #f))))
 
-             ((eqv? first '##include-str)
+             ((eqv? first '##include-string)
               (expand-expr (read-str-resource (parse-resource (cadr expr))) mtx))
 
              (else
@@ -2139,6 +2139,15 @@
     (if reader
       ((cadr reader) resource-path)
       (error "No resource reader found for resource-type:" (resource-type resource)))))
+
+(define (read-char-list input-port)
+  (let loop ((c (read-char input-port)))
+    (cond 
+      ((eof-object? c) '())
+      (else (cons c (loop (read-char input-port)))))))
+
+(define (read-str-resource resource)
+  (list->string (read-char-list (get-resource-port resource))))
 
 (define (expand-resource resource mtx)
   (let ((old-current-resource current-resource))

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -5030,7 +5030,7 @@ The output is written to output.c, with an executable compiled to run-output.exe
     (if (not src-path)
 
       (begin
-        (display "*** a Scheme source file must be specified\n")
+        (error "*** a Scheme source file must be specified\n")
         (exit-program-abnormally))
 
       (fancy-compiler

--- a/src/rsc.scm
+++ b/src/rsc.scm
@@ -4771,9 +4771,7 @@
   (let* ((vm-source
            (if (equal? _target "rvm")
              #f
-             (string-from-file rvm-path
-               #;(path-expand rvm-path
-                            (root-dir)))))
+             (string-from-file rvm-path)))
          (host-file
            (if (equal? _target "rvm")
              #f


### PR DESCRIPTION
1. Added `bin/rsc` so adding rsc to PATH is easier
2. Changed the implementation of the `shell-cmd` primitive for js to return the output, even when the subprocess fails
3. Added `--prefix-code` cli option to rsc.scm.
  - `--prefix-code <FILE.scm>`: inlines the content of `<FILE.scm>` before the content of the source file.
4. Fix a bug where the `--rvm` option only took a path from the `ribbit-root` (now it is relative to the caller of `rsc`)